### PR TITLE
feat(frontend): adding repository description in catalog

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,7 +16,10 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
-  "dependencies": {},
+  "dependencies": {
+    "marked": "^17.0.1",
+    "dompurify": "^3.3.1"
+  },
   "devDependencies": {
     "@podman-desktop/extension-hummingbird-core-api": "workspace:^",
     "@fortawesome/fontawesome-free": "^7.1.0",

--- a/packages/frontend/src/lib/cards/RepositoryCard.svelte
+++ b/packages/frontend/src/lib/cards/RepositoryCard.svelte
@@ -4,6 +4,8 @@ import { Button, TableDurationColumn } from '@podman-desktop/ui-svelte';
 import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
 import { faExternalLink } from '@fortawesome/free-solid-svg-icons/faExternalLink';
 import { dialogAPI } from '/@/api/client';
+import { getFirstParagraphAfterFirstHeading } from '/@/utils/markdown';
+import DOMPurify from 'dompurify';
 
 interface Props {
   object: Repository;
@@ -21,7 +23,7 @@ function openExternal(): Promise<boolean> {
 </script>
 
 <div
-  class="rounded-lg border border-[var(--pd-content-bg)] flex flex-col bg-[var(--pd-content-card-bg)] hover:border-[var(--pd-content-card-border-selected)] min-h-40 max-h-40"
+  class="rounded-lg border border-[var(--pd-content-bg)] flex flex-col bg-[var(--pd-content-card-bg)] hover:border-[var(--pd-content-card-border-selected)] min-h-48 max-h-48"
   role="group"
   aria-label={repository.name}>
   <div class="p-3 h-full w-full flex flex-col gap-y-4 justify-between">
@@ -41,17 +43,24 @@ function openExternal(): Promise<boolean> {
           </div>
         </div>
       </div>
-      <div class="pt-2 text-(--pd-content-text)">
-        Hardened {repository.name} image
-      </div>
 
-      <div class="flex">
-        <div class="flex flex row justify-between w-full text-(--pd-content-text)">
-          <span>Last updated</span>
-          <span class="flex gap-x-1">
-            <TableDurationColumn object={new Date(repository.last_modified * 1000)} />
-            ago
-          </span>
+      <div class="flex flex-col gap-y-2 divide-y divide-[var(--pd-content-divider)]">
+        {#if repository.description}
+          <div class="py-2 text-(--pd-content-text)">
+            <article class="line-clamp-2 overflow-hidden">
+              <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+              {@html DOMPurify.sanitize(getFirstParagraphAfterFirstHeading(repository.description) ?? '')}
+            </article>
+          </div>
+        {/if}
+        <div class="flex">
+          <div class="flex flex row justify-between w-full text-(--pd-content-text)">
+            <span>Last updated</span>
+            <span class="flex gap-x-1">
+              <TableDurationColumn object={new Date(repository.last_modified * 1000)} />
+              ago
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/frontend/src/utils/markdown.spec.ts
+++ b/packages/frontend/src/utils/markdown.spec.ts
@@ -1,0 +1,39 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { describe, test, expect } from 'vitest';
+import { getFirstParagraphAfterFirstHeading } from './markdown';
+
+describe('getFirstParagraphAfterFirstHeading', () => {
+  test.each([
+    {
+      name: 'basic case – first paragraph after H1',
+      markdown: `
+# Title
+
+First paragraph.
+
+Second paragraph.
+`,
+      expected: 'First paragraph.',
+    },
+  ])('$name', ({ markdown, expected }) => {
+    const result = getFirstParagraphAfterFirstHeading(markdown);
+    expect(result).toBe(expected);
+  });
+});

--- a/packages/frontend/src/utils/markdown.ts
+++ b/packages/frontend/src/utils/markdown.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { marked } from 'marked';
+import type { Tokens } from 'marked';
+
+/**
+ * Returns the first paragraph that appears after the first heading.
+ * If no matching heading or paragraph is found, returns null.
+ */
+export function getFirstParagraphAfterFirstHeading(markdown: string): string | undefined {
+  const lexer = new marked.Lexer();
+  const tokens = lexer.lex(markdown);
+
+  let seenHeading = false;
+
+  for (const token of tokens) {
+    if (token.type === 'heading' && !seenHeading) {
+      seenHeading = true;
+      continue;
+    }
+
+    if (seenHeading && token.type === 'paragraph') {
+      const text = (token as Tokens.Paragraph).text;
+      return marked.parse(text, { async: false });
+    }
+  }
+
+  return undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,13 @@ importers:
         version: 4.0.16(@types/node@24.10.9)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(yaml@2.8.2)
 
   packages/frontend:
+    dependencies:
+      dompurify:
+        specifier: ^3.3.1
+        version: 3.3.1
+      marked:
+        specifier: ^17.0.1
+        version: 17.0.1
     devDependencies:
       '@codecov/vite-plugin':
         specifier: ^1.9.1
@@ -1165,6 +1172,9 @@ packages:
   '@types/swagger-schema-official@2.0.25':
     resolution: {integrity: sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -1918,6 +1928,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
@@ -2725,6 +2738,11 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  marked@17.0.1:
+    resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   marked@5.1.2:
     resolution: {integrity: sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==}
@@ -4595,6 +4613,9 @@ snapshots:
 
   '@types/swagger-schema-official@2.0.25': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.33':
@@ -5425,6 +5446,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.2.3: {}
 
@@ -6364,6 +6389,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
+
+  marked@17.0.1: {}
 
   marked@5.1.2: {}
 


### PR DESCRIPTION
## Descripton

Adding the first paragraph of the repository description in the card.

<img width="1144" height="697" alt="image" src="https://github.com/user-attachments/assets/ecf06558-cc9d-441d-909d-b1e3cb8f45fc" />

## Related issues

Fix https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/26