### PR TITLE
chore(ci): introduce next-build.yaml workflow

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -1,0 +1,46 @@
+name: next-build.yaml
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Log in to ghcr.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ghcr.io/${{ github.repository }}
+          tags: next ${{ github.sha }}
+          containerfiles: ./Containerfile
+          extra-args: --squash-all
+
+      - name: Push Image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}


### PR DESCRIPTION
## Description

Use [redhat-actions/podman-login](https://github.com/redhat-actions/podman-login), [redhat-actions/push-to-registry](https://github.com/redhat-actions/push-to-registry), [redhat-actions/buildah-build](https://github.com/redhat-actions/buildah-build) for building and pushing the image to the repository registry.

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/33