### PR TITLE
chore(frontend): make grid break point smaller

### DIFF
--- a/packages/frontend/src/routes/+page.svelte
+++ b/packages/frontend/src/routes/+page.svelte
@@ -81,7 +81,7 @@ function refresh(): Promise<void> {
       <div class="flex flex-col w-full h-full">
         <!-- while we fetch the repositories we display skeleton cards -->
         {#await data.repositories}
-          <div class="grid min-[920px]:grid-cols-2 min-[1180px]:grid-cols-3 gap-3">
+          <div class="grid min-[720px]:grid-cols-2 min-[980px]:grid-cols-3 gap-3">
             {#each Array.from({ length: 10 }) as _, index (index)}
               <RepositoryCardSkeleton />
             {/each}
@@ -91,7 +91,7 @@ function refresh(): Promise<void> {
             searchTerm.length > 0
               ? repositories.filter(({ name }) => name.toLowerCase().includes(searchTerm.toLowerCase()))
               : repositories}
-          <div class="grid min-[920px]:grid-cols-2 min-[1180px]:grid-cols-3 gap-3">
+          <div class="grid min-[720px]:grid-cols-2 min-[980px]:grid-cols-3 gap-3">
             {#each filtered as repository (repository.name)}
               {@const pulled = data.pulled?.then(images =>
                 images.find(image => image.name.startsWith(`quay.io/hummingbird/${repository.name}`)),


### PR DESCRIPTION
## Description

Make the break point for the grid smaller. 

ℹ️ When doing the implementation I copied the values from the extension catalog, but the webview is a bit smaller than the full application, so it was inconsistent. 

### Screenshots

**Before**

<img width="901" height="703" alt="image" src="https://github.com/user-attachments/assets/66803f87-cbc2-418d-ad6e-843b15e1cf76" />


**After**

<img width="900" height="702" alt="image" src="https://github.com/user-attachments/assets/796f290c-1efd-47df-a526-e378d0d940a5" />



## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/69