### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default Owners
-* @redhat-developer/podman-desktop-reviewers @axel7083


### PR DESCRIPTION
reviewers are assigned by a GitHub app