### PR TITLE
fix(renderer): typecheck for hummingbird types

### DIFF
--- a/packages/backend/src/services/hummingbird-service.spec.ts
+++ b/packages/backend/src/services/hummingbird-service.spec.ts
@@ -38,6 +38,8 @@ const IMAGES_SUMMARY_MOCK: Array<ImageSummary> = [
     streams: [],
     tag_count: 0,
     variants: [],
+    application_category: '',
+    summary: '',
   },
 ];
 

--- a/packages/frontend/src/routes/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/page.svelte.spec.ts
@@ -42,6 +42,8 @@ const REPOSITORIES: Array<ImageSummary> = [
     streams: [],
     tag_count: 0,
     variants: [],
+    application_category: '',
+    summary: '',
   },
 ];
 


### PR DESCRIPTION
## Description

We are generating the Hummingbird client from the upstream OpenAPI spec, as they don't yet release v1, they are doing some small changes.

Recently they seems to have added two mandatory fields, in the mocks we create those properties without the new mandatory fields making typescript failing.