### PR TITLE
fix(renderer): router sync state

### DIFF
--- a/packages/frontend/src/routes/+layout.svelte
+++ b/packages/frontend/src/routes/+layout.svelte
@@ -12,7 +12,7 @@ import Navigation from '$lib/navigations/Navigation.svelte';
 let { children } = $props();
 
 const state = await getRouterState();
-if(state.url !== page.url.pathname) {
+if (state.url !== page.url.pathname) {
   // eslint-disable-next-line svelte/no-navigation-without-resolve
   goto(state.url).catch(console.error);
 }


### PR DESCRIPTION
## Description

Some weird issues with Sveltekit and the router. With https://github.com/redhat-developer/podman-desktop-hummingbird-ext/pull/195 we can use top level await in the layout component fixing the problem.

## Related issues

Requires rebase after
- https://github.com/redhat-developer/podman-desktop-hummingbird-ext/pull/195

Required for
- https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/182