### PR TITLE
refactor(frontend): remove data fetch from `+layout.ts`

### DIFF
--- a/packages/frontend/src/routes/+layout.ts
+++ b/packages/frontend/src/routes/+layout.ts
@@ -15,17 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { LayoutLoad } from './$types';
-import { hummingbirdAPI } from '/@/api/client';
-import type { ImageSummary } from '@podman-desktop/extension-hummingbird-core-api';
 
 export const prerender = true;
 export const ssr = false;
-
-export const load: LayoutLoad = async (): Promise<{
-  repositories: Promise<Array<ImageSummary>>;
-}> => {
-  return {
-    repositories: hummingbirdAPI.all(),
-  };
-};

--- a/packages/frontend/src/routes/+page.ts
+++ b/packages/frontend/src/routes/+page.ts
@@ -16,11 +16,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { PageLoad } from './$types';
-import type { SimpleImageInfo } from '@podman-desktop/extension-hummingbird-core-api';
-import { imageAPI } from '/@/api/client';
+import type { SimpleImageInfo, ImageSummary } from '@podman-desktop/extension-hummingbird-core-api';
+import { hummingbirdAPI, imageAPI } from '/@/api/client';
 
 interface Data {
   pulled?: Promise<Array<SimpleImageInfo>>;
+  repositories: Promise<Array<ImageSummary>>;
   providerId?: string;
   connection?: string;
 }
@@ -55,6 +56,7 @@ export const load: PageLoad = async ({ url, depends }): Promise<Data> => {
     ]).then(([images]) => images);
   }
   return {
+    repositories: hummingbirdAPI.all(),
     pulled,
     providerId,
     connection,


### PR DESCRIPTION
## Description

Moving the data fetching of Hummingbird repositories from the `+layout.ts` to `+page.ts`. This was a remaining from an old decision, which is causing issue now. (Typecheck is failing in https://github.com/redhat-developer/podman-desktop-hummingbird-ext/pull/204)

## Related issues

Required for 
- https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/182