### PR TITLE
feat(Alternative): implement CVEs column

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -21,7 +21,7 @@
   },
   "contributes": {},
   "devDependencies": {
-    "@podman-desktop/grype-extension-api": "^0.1.0-next.202603121655-ba645db",
+    "@podman-desktop/grype-extension-api": "^0.1.0-next.202604011405-f6be4bb",
     "@podman-desktop/extension-hummingbird-core-api": "workspace:^",
     "@podman-desktop/podman-extension-api": "^1.26.1",
     "@podman-desktop/api": "^1.26.1",

--- a/packages/backend/src/apis/alternatives-api-impl.spec.ts
+++ b/packages/backend/src/apis/alternatives-api-impl.spec.ts
@@ -1,0 +1,94 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { expect, test, vi, beforeEach, describe } from 'vitest';
+import { AlternativesApiImpl } from './alternatives-api-impl';
+import type { AlternativeService } from '../services/alternative-service';
+import type {
+  ImageSummary,
+  LocalImageAlternative,
+  LocalImageAlternativeReport,
+  VulnerabilitiesSummary,
+} from '@podman-desktop/extension-hummingbird-core-api';
+
+const ALTERNATIVE_SERVICE_MOCK: AlternativeService = {
+  getAlternatives: vi.fn(),
+  getAlternativeReport: vi.fn(),
+} as unknown as AlternativeService;
+
+const LOCAL_IMAGE_ALT_MOCK: LocalImageAlternative = {
+  localImage: {
+    engineId: 'engine1',
+    id: 'image1',
+    name: 'image1',
+    tag: 'tag1',
+    size: 55,
+    architecture: 'amd64',
+  },
+  alternative: {
+    name: 'foo',
+  } as ImageSummary,
+};
+
+const LOCAL_IMAGE_ALT_REPORT_MOCK: LocalImageAlternativeReport = {
+  localImage: {
+    vulnerabilities: {} as VulnerabilitiesSummary,
+  },
+  alternative: {
+    vulnerabilities: {} as VulnerabilitiesSummary,
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('AlternativesApiImpl#getAlternatives', () => {
+  test('expect getAlternatives result to be properly propagated from AlternativeService', async () => {
+    vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternatives).mockResolvedValue([LOCAL_IMAGE_ALT_MOCK]);
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+    const result = await api.getAlternatives();
+    expect(result).toStrictEqual([LOCAL_IMAGE_ALT_MOCK]);
+  });
+
+  test('expect getAlternatives error to be propagated', async () => {
+    vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternatives).mockRejectedValue(new Error('Failed to get alternatives'));
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+
+    await expect(() => {
+      return api.getAlternatives();
+    }).rejects.toThrowError('Failed to get alternatives');
+  });
+});
+
+describe('AlternativesApiImpl#getAlternativeReport', () => {
+  test('expect getAlternativeReport result to be properly propagated from AlternativeService', async () => {
+    vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternativeReport).mockResolvedValue(LOCAL_IMAGE_ALT_REPORT_MOCK);
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+    const result = await api.getAlternativeReport(LOCAL_IMAGE_ALT_MOCK);
+    expect(result).toStrictEqual(LOCAL_IMAGE_ALT_REPORT_MOCK);
+  });
+
+  test('expect getAlternativeReport error to be propagated', async () => {
+    vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternativeReport).mockRejectedValue(new Error('Failed to get report'));
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+
+    await expect(() => {
+      return api.getAlternativeReport(LOCAL_IMAGE_ALT_MOCK);
+    }).rejects.toThrowError('Failed to get report');
+  });
+});

--- a/packages/backend/src/apis/alternatives-api-impl.ts
+++ b/packages/backend/src/apis/alternatives-api-impl.ts
@@ -15,7 +15,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { AlternativesApi, LocalImageAlternative } from '@podman-desktop/extension-hummingbird-core-api';
+import {
+  AlternativesApi,
+  LocalImageAlternative,
+  LocalImageAlternativeReport,
+} from '@podman-desktop/extension-hummingbird-core-api';
 import { inject, injectable } from 'inversify';
 import { AlternativeService } from '../services/alternative-service';
 
@@ -30,5 +34,9 @@ export class AlternativesApiImpl extends AlternativesApi {
 
   override async getAlternatives(): Promise<LocalImageAlternative[]> {
     return this.alternativeService.getAlternatives();
+  }
+
+  override getAlternativeReport(alternative: LocalImageAlternative): Promise<LocalImageAlternativeReport> {
+    return this.alternativeService.getAlternativeReport(alternative);
   }
 }

--- a/packages/backend/src/services/alternative-service.spec.ts
+++ b/packages/backend/src/services/alternative-service.spec.ts
@@ -16,12 +16,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi, beforeEach } from 'vitest';
+import { expect, test, vi, beforeEach, describe } from 'vitest';
 import type { TelemetryLogger, ImageInfo } from '@podman-desktop/api';
 import { containerEngine } from '@podman-desktop/api';
 import { AlternativeService } from './alternative-service';
 import type { HummingbirdService } from './hummingbird-service';
-import type { ImageSummary } from '@podman-desktop/extension-hummingbird-core-api';
+import type {
+  ImageSummary,
+  LocalImageAlternative,
+  VulnerabilitiesSummary,
+} from '@podman-desktop/extension-hummingbird-core-api';
+import type { GrypeService } from './scanners/grype-service';
+import type { grype } from '@podman-desktop/grype-extension-api';
 
 const TELEMETRY_LOGGER_MOCK: TelemetryLogger = {
   logUsage: vi.fn(),
@@ -34,6 +40,7 @@ const TELEMETRY_LOGGER_MOCK: TelemetryLogger = {
 
 const HUMMINGBIRD_SERVICE_MOCK = {
   getImages: vi.fn(),
+  getVulnerabilitiesSummary: vi.fn(),
 } as unknown as HummingbirdService;
 
 const HUMMINGBIRD_IMAGES_MOCK: Array<ImageSummary> = [
@@ -63,13 +70,22 @@ const HUMMINGBIRD_IMAGES_MOCK: Array<ImageSummary> = [
   },
 ];
 
+const GRYPE_SERVICE_MOCK: GrypeService = {
+  api: {
+    vulnerability: {
+      analyse: vi.fn(),
+    },
+  },
+  toVulnerabilitySummary: vi.fn(),
+} as unknown as GrypeService;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(HUMMINGBIRD_SERVICE_MOCK.getImages).mockResolvedValue(HUMMINGBIRD_IMAGES_MOCK);
 });
 
 function getAlternativeService(): AlternativeService {
-  return new AlternativeService(TELEMETRY_LOGGER_MOCK, HUMMINGBIRD_SERVICE_MOCK);
+  return new AlternativeService(TELEMETRY_LOGGER_MOCK, HUMMINGBIRD_SERVICE_MOCK, GRYPE_SERVICE_MOCK);
 }
 
 test('should return alternatives for matching local images', async () => {
@@ -176,4 +192,87 @@ test('should handle multiple images with alternatives', async () => {
   expect(result).toHaveLength(2);
   expect(result[0].localImage.name).toBe('docker.io/library/nginx');
   expect(result[1].localImage.name).toBe('docker.io/library/python');
+});
+
+describe('AlternativeService#getAlternativeReport', () => {
+  test('should return vulnerability report for alternative and local image', async () => {
+    const mockAlternative: LocalImageAlternative = {
+      localImage: {
+        id: 'sha256:abc123',
+        engineId: 'podman',
+        name: 'docker.io/library/nginx',
+        tag: 'latest',
+        size: 1024000,
+        architecture: 'amd64',
+      },
+      alternative: {
+        name: 'nginx',
+        latest_tag: '1.21',
+      } as ImageSummary,
+    };
+
+    const mockAltVulnerabilities: VulnerabilitiesSummary = {
+      critical: 0,
+      high: 1,
+      medium: 2,
+      low: 3,
+      negligible: 0,
+      unknown: 0,
+      total: 6,
+    };
+
+    const mockLocalGrypeDocument: grype.Document = {
+      matches: [
+        {
+          vulnerability: {
+            severity: 'critical',
+          },
+        },
+        {
+          vulnerability: {
+            severity: 'high',
+          },
+        },
+      ],
+    } as grype.Document;
+
+    const mockLocalVulnerabilities: VulnerabilitiesSummary = {
+      critical: 1,
+      high: 1,
+      medium: 0,
+      low: 0,
+      negligible: 0,
+      unknown: 0,
+      total: 2,
+    };
+
+    vi.mocked(HUMMINGBIRD_SERVICE_MOCK.getVulnerabilitiesSummary).mockResolvedValue(mockAltVulnerabilities);
+    vi.mocked(GRYPE_SERVICE_MOCK.api.vulnerability.analyse).mockResolvedValue(mockLocalGrypeDocument);
+    vi.mocked(GRYPE_SERVICE_MOCK.toVulnerabilitySummary).mockReturnValue(mockLocalVulnerabilities);
+
+    const service = getAlternativeService();
+    const result = await service.getAlternativeReport(mockAlternative);
+
+    expect(result).toStrictEqual({
+      localImage: {
+        vulnerabilities: mockLocalVulnerabilities,
+      },
+      alternative: {
+        vulnerabilities: mockAltVulnerabilities,
+      },
+    });
+
+    expect(HUMMINGBIRD_SERVICE_MOCK.getVulnerabilitiesSummary).toHaveBeenCalledWith('nginx', '1.21');
+    expect(GRYPE_SERVICE_MOCK.api.vulnerability.analyse).toHaveBeenCalledWith(
+      {
+        engineId: 'podman',
+        Id: 'sha256:abc123',
+      },
+      expect.objectContaining({
+        task: {
+          title: 'Scanning docker.io/library/nginx:latest',
+        },
+      }),
+    );
+  });
 });

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -1,20 +1,50 @@
-import { inject, injectable } from 'inversify';
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { inject, injectable, preDestroy } from 'inversify';
 import { TelemetryLoggerSymbol } from '../inject/symbol';
-import type { TelemetryLogger } from '@podman-desktop/api';
-import { containerEngine as containerEngineAPI } from '@podman-desktop/api';
+import {
+  CancellationTokenSource,
+  containerEngine as containerEngineAPI,
+  Disposable,
+  TelemetryLogger,
+} from '@podman-desktop/api';
 import { HummingbirdService } from './hummingbird-service';
-import { LocalImageAlternative } from '@podman-desktop/extension-hummingbird-core-api';
+import type {
+  LocalImageAlternative,
+  LocalImageAlternativeReport,
+} from '@podman-desktop/extension-hummingbird-core-api';
 import alt from '../assets/alt.json' with { type: 'json' };
+import { GrypeService } from './scanners/grype-service';
+import { PromiseQueue } from '../utils/promise-queue';
 
 @injectable()
-export class AlternativeService {
+export class AlternativeService implements Disposable {
   #altMap: Map<string, string>;
+  #queue: PromiseQueue = new PromiseQueue(2);
+  #cancellationToken = new CancellationTokenSource();
 
   constructor(
     @inject(TelemetryLoggerSymbol)
     protected readonly telemetryLogger: TelemetryLogger,
     @inject(HummingbirdService)
     protected readonly hummingbirdService: HummingbirdService,
+    @inject(GrypeService)
+    protected readonly grypeService: GrypeService,
   ) {
     // Create reverse mapping: from alternative repo to hummingbird image name
     this.#altMap = new Map(
@@ -79,5 +109,42 @@ export class AlternativeService {
     }
 
     return results;
+  }
+
+  public async getAlternativeReport({
+    alternative,
+    localImage,
+  }: LocalImageAlternative): Promise<LocalImageAlternativeReport> {
+    const [altVulnerabilities, localVulnerabilities] = await this.#queue.enqueue(() =>
+      Promise.all([
+        this.hummingbirdService.getVulnerabilitiesSummary(alternative.name, alternative.latest_tag),
+        this.grypeService.api.vulnerability.analyse(
+          {
+            engineId: localImage.engineId,
+            Id: localImage.id,
+          },
+          {
+            task: {
+              title: `Scanning ${localImage.name}:${localImage.tag}`,
+            },
+            token: this.#cancellationToken.token,
+          },
+        ),
+      ]),
+    );
+
+    return {
+      localImage: {
+        vulnerabilities: this.grypeService.toVulnerabilitySummary(localVulnerabilities),
+      },
+      alternative: {
+        vulnerabilities: altVulnerabilities,
+      },
+    };
+  }
+
+  @preDestroy()
+  dispose(): void {
+    this.#cancellationToken.cancel();
   }
 }

--- a/packages/backend/src/services/hummingbird-service.ts
+++ b/packages/backend/src/services/hummingbird-service.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { Disposable } from '@podman-desktop/api';
-import type { ImageSummary } from '@podman-desktop/extension-hummingbird-core-api';
+import type { ImageSummary, VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-core-api';
 import { Api } from '@podman-desktop/extension-hummingbird-core-api';
 import { injectable, preDestroy } from 'inversify';
 
@@ -38,6 +38,11 @@ export class HummingbirdService implements Disposable {
     this.#cache = res.data.images;
 
     return this.#cache;
+  }
+
+  public async getVulnerabilitiesSummary(image: string, canonical: string): Promise<VulnerabilitiesSummary> {
+    const res = await this.#client.v1.getVulnerabilities(image, canonical);
+    return res.data.summary;
   }
 
   @preDestroy()

--- a/packages/backend/src/services/scanners/grype-service.spec.ts
+++ b/packages/backend/src/services/scanners/grype-service.spec.ts
@@ -17,9 +17,9 @@
  ***********************************************************************/
 import type { Extension } from '@podman-desktop/api';
 import { extensions as extensionsAPI } from '@podman-desktop/api';
-import type { GrypeExtensionApi } from '@podman-desktop/grype-extension-api';
+import type { GrypeExtensionApi, grype } from '@podman-desktop/grype-extension-api';
 
-import { beforeEach, vi, test, expect } from 'vitest';
+import { beforeEach, vi, test, expect, describe } from 'vitest';
 import { GrypeService } from '/@/services/scanners/grype-service';
 
 const GRYPE_EXTENSION_API_MOCK: GrypeExtensionApi = {} as GrypeExtensionApi;
@@ -52,4 +52,56 @@ test('should throw error when extension is undefined', () => {
   const service = getGrypeService();
 
   expect(() => service['getGrypeAPI']()).toThrowError('cannot find the grype extension');
+});
+
+describe('GrypeService#toVulnerabilitySummary', () => {
+  test('should count vulnerabilities by severity', () => {
+    const mockDocument: grype.Document = {
+      matches: [
+        {
+          vulnerability: {
+            severity: 'critical',
+          },
+        },
+        {
+          vulnerability: {
+            severity: 'high',
+          },
+        },
+        {
+          vulnerability: {
+            severity: 'high',
+          },
+        },
+        {
+          vulnerability: {
+            severity: 'medium',
+          },
+        },
+        {
+          vulnerability: {
+            severity: 'low',
+          },
+        },
+        {
+          vulnerability: {
+            severity: 'unknown',
+          },
+        },
+      ],
+    } as grype.Document;
+
+    const service = getGrypeService();
+    const result = service.toVulnerabilitySummary(mockDocument);
+
+    expect(result).toStrictEqual({
+      critical: 1,
+      high: 2,
+      medium: 1,
+      low: 1,
+      negligible: 0,
+      unknown: 1,
+      total: 6,
+    });
+  });
 });

--- a/packages/backend/src/services/scanners/grype-service.ts
+++ b/packages/backend/src/services/scanners/grype-service.ts
@@ -18,14 +18,15 @@
 import type { Disposable } from '@podman-desktop/api';
 import { extensions as extensionsAPI } from '@podman-desktop/api';
 import type { AsyncInit } from '/@/utils/async-init';
-import type { GrypeExtensionApi } from '@podman-desktop/grype-extension-api';
+import type { GrypeExtensionApi, grype } from '@podman-desktop/grype-extension-api';
 import { injectable } from 'inversify';
+import { VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-core-api';
 
 @injectable()
 export class GrypeService implements AsyncInit, Disposable {
   #api: GrypeExtensionApi | undefined;
 
-  get api(): GrypeExtensionApi | undefined {
+  get api(): GrypeExtensionApi {
     if (this.#api) {
       return this.#api;
     }
@@ -35,6 +36,42 @@ export class GrypeService implements AsyncInit, Disposable {
 
   dispose(): void {
     this.#api = undefined;
+  }
+
+  public toVulnerabilitySummary(document: grype.Document): VulnerabilitiesSummary {
+    return document.matches.reduce(
+      (accumulator, match) => {
+        switch (match.vulnerability.severity) {
+          case 'high':
+            accumulator.high++;
+            break;
+          case 'critical':
+            accumulator.critical++;
+            break;
+          case 'medium':
+            accumulator.medium++;
+            break;
+          case 'low':
+            accumulator.low++;
+            break;
+          default:
+            accumulator.unknown++;
+            break;
+        }
+        accumulator.total++;
+
+        return accumulator;
+      },
+      {
+        critical: 0,
+        high: 0,
+        low: 0,
+        medium: 0,
+        negligible: 0,
+        total: 0,
+        unknown: 0,
+      } as VulnerabilitiesSummary,
+    );
   }
 
   protected getGrypeAPI(): GrypeExtensionApi {

--- a/packages/backend/src/utils/promise-queue.spec.ts
+++ b/packages/backend/src/utils/promise-queue.spec.ts
@@ -1,0 +1,211 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import { describe, expect, test, vi } from 'vitest';
+import { PromiseQueue } from './promise-queue';
+
+describe('PromiseQueue', () => {
+  test('should execute a single task', async () => {
+    const queue = new PromiseQueue();
+    const result = await queue.enqueue(async () => 'hello');
+    expect(result).toBe('hello');
+  });
+
+  test('should preserve return types', async () => {
+    const queue = new PromiseQueue();
+    const numberResult = await queue.enqueue(async () => 42);
+    const stringResult = await queue.enqueue(async () => 'test');
+    const objectResult = await queue.enqueue(async () => ({ id: 1 }));
+
+    expect(numberResult).toBe(42);
+    expect(stringResult).toBe('test');
+    expect(objectResult).toEqual({ id: 1 });
+  });
+
+  test('should respect concurrency limit', async () => {
+    const queue = new PromiseQueue(2);
+    const { promise: p1, resolve: r1 } = Promise.withResolvers<number>();
+    const { promise: p2, resolve: r2 } = Promise.withResolvers<number>();
+    const { promise: p3, resolve: r3 } = Promise.withResolvers<number>();
+
+    // Enqueue 3 tasks
+    queue.enqueue(() => p1).catch(console.error);
+    queue.enqueue(() => p2).catch(console.error);
+    queue.enqueue(() => p3).catch(console.error);
+
+    // With limit of 2, only 2 should be running
+    expect(queue.runningCount).toBe(2);
+    expect(queue.queuedCount).toBe(1);
+
+    // Complete one task
+    r1(1);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    // Now the third should start
+    expect(queue.runningCount).toBe(2);
+    expect(queue.queuedCount).toBe(0);
+
+    // Complete remaining
+    r2(2);
+    r3(3);
+  });
+
+  test('should process queued tasks as running tasks complete', async () => {
+    const queue = new PromiseQueue(1);
+    const { promise: p1, resolve: r1 } = Promise.withResolvers<string>();
+    const { promise: p2, resolve: r2 } = Promise.withResolvers<string>();
+
+    const result1Promise = queue.enqueue(() => p1);
+    const result2Promise = queue.enqueue(() => p2);
+
+    expect(queue.runningCount).toBe(1);
+    expect(queue.queuedCount).toBe(1);
+
+    // Complete first task
+    r1('first');
+    const result1 = await result1Promise;
+    expect(result1).toBe('first');
+
+    // Second task should now be running
+
+    await vi.waitFor(() => {
+      expect(queue.runningCount).toBe(1);
+      expect(queue.queuedCount).toBe(0);
+    });
+
+    // Complete second task
+    r2('second');
+    const result2 = await result2Promise;
+
+    expect(result2).toBe('second');
+
+    await vi.waitFor(() => {
+      expect(queue.runningCount).toBe(0);
+      expect(queue.queuedCount).toBe(0);
+    });
+  });
+
+  test('should handle promise rejections', async () => {
+    const queue = new PromiseQueue();
+    const error = new Error('Task failed');
+
+    await expect(
+      queue.enqueue(async () => {
+        throw error;
+      }),
+    ).rejects.toThrowError('Task failed');
+
+    // Queue should still work after rejection
+    const result = await queue.enqueue(async () => 'works');
+    expect(result).toBe('works');
+  });
+
+  test('should handle multiple concurrent tasks with different completion times', async () => {
+    const queue = new PromiseQueue(3);
+    const { promise: p1, resolve: r1 } = Promise.withResolvers<number>();
+    const { promise: p2, resolve: r2 } = Promise.withResolvers<number>();
+    const { promise: p3, resolve: r3 } = Promise.withResolvers<number>();
+
+    const result1Promise = queue.enqueue(() => p1);
+    const result2Promise = queue.enqueue(() => p2);
+    const result3Promise = queue.enqueue(() => p3);
+
+    expect(queue.runningCount).toBe(3);
+
+    // Resolve in different order
+    r2(20);
+    r1(10);
+    r3(30);
+
+    const [result1, result2, result3] = await Promise.all([result1Promise, result2Promise, result3Promise]);
+
+    expect(result1).toBe(10);
+    expect(result2).toBe(20);
+    expect(result3).toBe(30);
+
+    await vi.waitFor(() => {
+      expect(queue.runningCount).toBe(0);
+    });
+  });
+
+  test('should execute tasks sequentially with concurrency of 1', async () => {
+    const queue = new PromiseQueue(1);
+    const executionOrder: number[] = [];
+
+    const task1 = queue.enqueue(async () => {
+      executionOrder.push(1);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      executionOrder.push(1);
+    });
+
+    const task2 = queue.enqueue(async () => {
+      executionOrder.push(2);
+      await new Promise(resolve => setTimeout(resolve, 10));
+      executionOrder.push(2);
+    });
+
+    await Promise.all([task1, task2]);
+
+    // With concurrency 1, task 1 should complete before task 2 starts
+    expect(executionOrder).toEqual([1, 1, 2, 2]);
+  });
+
+  test('should throw error if maxConcurrent is less than 1', () => {
+    expect(() => new PromiseQueue(0)).toThrowError('maxConcurrent must be at least 1');
+    expect(() => new PromiseQueue(-1)).toThrowError('maxConcurrent must be at least 1');
+  });
+
+  test('should update counts correctly throughout execution', async () => {
+    const queue = new PromiseQueue(2);
+    const { promise: p1, resolve: r1 } = Promise.withResolvers<void>();
+    const { promise: p2, resolve: r2 } = Promise.withResolvers<void>();
+    const { promise: p3, resolve: r3 } = Promise.withResolvers<void>();
+    const { promise: p4, resolve: r4 } = Promise.withResolvers<void>();
+
+    queue.enqueue(() => p1).catch(console.error);
+    queue.enqueue(() => p2).catch(console.error);
+    queue.enqueue(() => p3).catch(console.error);
+    queue.enqueue(() => p4).catch(console.error);
+
+    expect(queue.runningCount).toBe(2);
+    expect(queue.queuedCount).toBe(2);
+
+    r1();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(queue.runningCount).toBe(2);
+    expect(queue.queuedCount).toBe(1);
+
+    r2();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(queue.runningCount).toBe(2);
+    expect(queue.queuedCount).toBe(0);
+
+    r3();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(queue.runningCount).toBe(1);
+    expect(queue.queuedCount).toBe(0);
+
+    r4();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(queue.runningCount).toBe(0);
+    expect(queue.queuedCount).toBe(0);
+  });
+});

--- a/packages/backend/src/utils/promise-queue.ts
+++ b/packages/backend/src/utils/promise-queue.ts
@@ -1,0 +1,90 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+/**
+ * A queue that limits the number of concurrent promise executions.
+ * When the limit is reached, new promises are queued and executed as previous ones complete.
+ */
+export class PromiseQueue {
+  private queue: Array<() => void> = [];
+  private running: number = 0;
+  private maxConcurrent: number;
+
+  /**
+   * Creates a new PromiseQueue
+   * @param maxConcurrent - Maximum number of promises that can run concurrently (default: 1)
+   */
+  constructor(maxConcurrent: number = 2) {
+    if (maxConcurrent < 1) {
+      throw new Error('maxConcurrent must be at least 1');
+    }
+    this.maxConcurrent = maxConcurrent;
+  }
+
+  /**
+   * Enqueues a function that returns a promise.
+   * Returns a promise that resolves/rejects when the enqueued function's promise resolves/rejects.
+   * @param fn - Function that returns a promise
+   * @returns Promise that resolves with the same value as the input function's promise
+   */
+  enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const task = (): void => {
+        this.running++;
+        fn()
+          .then(resolve)
+          .catch(reject)
+          .finally(() => {
+            this.running--;
+            this.processNext();
+          });
+      };
+
+      this.queue.push(task);
+      this.processNext();
+    });
+  }
+
+  /**
+   * Processes the next task in the queue if capacity is available
+   */
+  private processNext(): void {
+    if (this.running >= this.maxConcurrent || this.queue.length === 0) {
+      return;
+    }
+
+    const task = this.queue.shift();
+    if (task) {
+      task();
+    }
+  }
+
+  /**
+   * Returns the number of currently running tasks
+   */
+  get runningCount(): number {
+    return this.running;
+  }
+
+  /**
+   * Returns the number of tasks waiting in the queue
+   */
+  get queuedCount(): number {
+    return this.queue.length;
+  }
+}

--- a/packages/frontend/src/lib/cves/SimpleLocalImageAlternativeReport.spec.ts
+++ b/packages/frontend/src/lib/cves/SimpleLocalImageAlternativeReport.spec.ts
@@ -1,0 +1,153 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import SimpleLocalImageAlternativeReport from './SimpleLocalImageAlternativeReport.svelte';
+import type { LocalImageAlternativeReport } from '@podman-desktop/extension-hummingbird-core-api';
+
+test('should display local and alternative vulnerability counts', () => {
+  const report: LocalImageAlternativeReport = {
+    localImage: {
+      vulnerabilities: {
+        critical: 5,
+        high: 10,
+        medium: 20,
+        low: 15,
+        negligible: 0,
+        unknown: 0,
+        total: 50,
+      },
+    },
+    alternative: {
+      vulnerabilities: {
+        critical: 1,
+        high: 2,
+        medium: 5,
+        low: 5,
+        negligible: 0,
+        unknown: 0,
+        total: 13,
+      },
+    },
+  };
+
+  render(SimpleLocalImageAlternativeReport, { object: report });
+
+  expect(screen.getByText('50')).toBeInTheDocument();
+  expect(screen.getByText('13')).toBeInTheDocument();
+});
+
+test('should display CVE reduction count and percentage', () => {
+  const report: LocalImageAlternativeReport = {
+    localImage: {
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 100,
+      },
+    },
+    alternative: {
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 25,
+      },
+    },
+  };
+
+  render(SimpleLocalImageAlternativeReport, { object: report });
+
+  expect(screen.getByText('75 CVEs eliminated')).toBeInTheDocument();
+  expect(screen.getByText('(75%)')).toBeInTheDocument();
+});
+
+test('should display "No change" when reduction is zero', () => {
+  const report: LocalImageAlternativeReport = {
+    localImage: {
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 10,
+      },
+    },
+    alternative: {
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 10,
+      },
+    },
+  };
+
+  render(SimpleLocalImageAlternativeReport, { object: report });
+
+  expect(screen.getByText('No change')).toBeInTheDocument();
+});
+
+test('should round reduction percentage', () => {
+  const report: LocalImageAlternativeReport = {
+    localImage: {
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 3,
+      },
+    },
+    alternative: {
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 1,
+      },
+    },
+  };
+
+  render(SimpleLocalImageAlternativeReport, { object: report });
+
+  // (3-1)/3 * 100 = 66.666... which should round to 67
+  expect(screen.getByText('2 CVEs eliminated')).toBeInTheDocument();
+  expect(screen.getByText('(67%)')).toBeInTheDocument();
+});

--- a/packages/frontend/src/lib/cves/SimpleLocalImageAlternativeReport.svelte
+++ b/packages/frontend/src/lib/cves/SimpleLocalImageAlternativeReport.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+import type { LocalImageAlternativeReport } from '@podman-desktop/extension-hummingbird-core-api';
+
+interface Props {
+  object: LocalImageAlternativeReport;
+}
+
+let { object }: Props = $props();
+
+let reduction = $derived.by(() => {
+  return object.localImage.vulnerabilities.total - object.alternative.vulnerabilities.total;
+});
+
+let reductionPercent = $derived.by(() => {
+  if (object.localImage.vulnerabilities.total === 0) return undefined;
+  return Math.round(
+    ((object.localImage.vulnerabilities.total - object.alternative.vulnerabilities.total) /
+      object.localImage.vulnerabilities.total) *
+      100,
+  );
+});
+</script>
+
+<div class="flex flex-col items-center">
+  <div class="flex items-center gap-2">
+    <span class="text-base font-semibold" class:text-red-400={object.localImage.vulnerabilities.total > 0}>
+      {object.localImage.vulnerabilities.total}
+    </span>
+    <span class="text-[var(--pd-content-text)] opacity-30">→</span>
+    <span class="text-base font-semibold text-green-400">{object.alternative.vulnerabilities.total}</span>
+  </div>
+  {#if reduction !== undefined && reduction > 0}
+    <div class="flex items-center gap-1">
+      <span class="text-base text-[var(--pd-content-text)]">{reduction} CVEs eliminated</span>
+      {#if reductionPercent !== undefined}
+        <span class="text-base text-[var(--pd-content-text)]">({reductionPercent}%)</span>
+      {/if}
+    </div>
+  {:else if reduction === 0}
+    <span class="text-base text-[var(--pd-content-text)] opacity-50">No change</span>
+  {/if}
+</div>

--- a/packages/frontend/src/lib/skeleton/TableColumnSkeleton.svelte
+++ b/packages/frontend/src/lib/skeleton/TableColumnSkeleton.svelte
@@ -5,9 +5,12 @@ interface Props {
   object: SkeletonRow;
 }
 
-let { object: _ }: Props = $props();
+let { object }: Props = $props();
 </script>
 
-<div class="h-full w-full flex flex-col gap-y-4 justify-between animate-pulse">
+<div
+  class="h-full w-full flex flex-col gap-y-4 justify-between animate-pulse"
+  aria-busy="true"
+  aria-label={object.name}>
   <div class="h-2 size-40 rounded bg-gray-900"></div>
 </div>

--- a/packages/frontend/src/lib/table/CVEReductionCell.spec.ts
+++ b/packages/frontend/src/lib/table/CVEReductionCell.spec.ts
@@ -1,0 +1,81 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+
+import CVEReductionCell from './CVEReductionCell.svelte';
+import type { LocalImageAlternativeReport } from '@podman-desktop/extension-hummingbird-core-api';
+
+test('should display skeleton when promise is pending', () => {
+  const { promise } = Promise.withResolvers<LocalImageAlternativeReport>();
+
+  render(CVEReductionCell, { object: promise });
+
+  const skeleton = screen.getByLabelText('CVEs');
+  expect(skeleton).toBeInTheDocument();
+  expect(skeleton).toHaveAttribute('aria-busy', 'true');
+});
+
+test('should display report when promise resolves', async () => {
+  const report: LocalImageAlternativeReport = {
+    localImage: {
+      vulnerabilities: {
+        critical: 5,
+        high: 10,
+        medium: 20,
+        low: 15,
+        negligible: 0,
+        unknown: 0,
+        total: 50,
+      },
+    },
+    alternative: {
+      vulnerabilities: {
+        critical: 1,
+        high: 2,
+        medium: 5,
+        low: 5,
+        negligible: 0,
+        unknown: 0,
+        total: 13,
+      },
+    },
+  };
+
+  render(CVEReductionCell, { object: Promise.resolve(report) });
+
+  await vi.waitFor(() => {
+    expect(screen.getByText('50')).toBeInTheDocument();
+    expect(screen.getByText('13')).toBeInTheDocument();
+    expect(screen.getByText('37 CVEs eliminated')).toBeInTheDocument();
+  });
+});
+
+test('should display error message when promise rejects', async () => {
+  const error = new Error('Failed to scan image');
+
+  render(CVEReductionCell, { object: Promise.reject(error) });
+
+  await vi.waitFor(() => {
+    expect(screen.getByText(/Error scanning/)).toBeInTheDocument();
+    expect(screen.getByText(/Failed to scan image/)).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/lib/table/CVEReductionCell.svelte
+++ b/packages/frontend/src/lib/table/CVEReductionCell.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+import SimpleLocalImageAlternativeReport from '$lib/cves/SimpleLocalImageAlternativeReport.svelte';
+import type { LocalImageAlternativeReport } from '@podman-desktop/extension-hummingbird-core-api';
+import TableColumnSkeleton from '$lib/skeleton/TableColumnSkeleton.svelte';
+
+interface Props {
+  object: Promise<LocalImageAlternativeReport>;
+}
+
+let { object }: Props = $props();
+</script>
+
+{#await object}
+  <TableColumnSkeleton object={{ name: 'CVEs' }} />
+{:then report}
+  <SimpleLocalImageAlternativeReport object={report} />
+{:catch error}
+  <span class="text-xs text-red-400">Error scanning {error}</span>
+{/await}

--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -1,10 +1,16 @@
 <script lang="ts">
 import { TableColumn, Table, TableSimpleColumn, TableRow } from '@podman-desktop/ui-svelte';
-import type { LocalImageAlternative } from '@podman-desktop/extension-hummingbird-core-api';
+import type {
+  LocalImageAlternative,
+  LocalImageAlternativeReport,
+} from '@podman-desktop/extension-hummingbird-core-api';
+import CVEReductionCell from '$lib/table/CVEReductionCell.svelte';
+import { alternativesAPI } from '/@/api/client';
 
 interface AlternativeRow extends LocalImageAlternative {
   name: string;
   selected?: boolean;
+  report: Promise<LocalImageAlternativeReport>;
 }
 
 interface Props {
@@ -17,6 +23,7 @@ let data: AlternativeRow[] = $derived(
   alternatives.map(alt => ({
     ...alt,
     name: alt.localImage.name,
+    report: alternativesAPI.getAlternativeReport(alt),
   })),
 );
 
@@ -33,10 +40,10 @@ const columns = [
     renderMapping: (row: AlternativeRow): string => row.localImage.name,
     overflow: true,
   }),
-  new TableColumn<AlternativeRow, string>('CVEs', {
+  new TableColumn<AlternativeRow, Promise<LocalImageAlternativeReport>>('CVEs', {
     width: '1fr',
-    renderer: TableSimpleColumn,
-    renderMapping: (_: AlternativeRow): string => 'N/A',
+    renderer: CVEReductionCell,
+    renderMapping: ({ report }): Promise<LocalImageAlternativeReport> => report,
     overflow: true,
   }),
   new TableColumn<AlternativeRow, string>('Size Reduction', {

--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -37,7 +37,7 @@ const columns = [
   new TableColumn<AlternativeRow, string>('Alternative', {
     width: '1.5fr',
     renderer: TableSimpleColumn,
-    renderMapping: (row: AlternativeRow): string => row.localImage.name,
+    renderMapping: (row: AlternativeRow): string => row.alternative.name,
     overflow: true,
   }),
   new TableColumn<AlternativeRow, Promise<LocalImageAlternativeReport>>('CVEs', {

--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -10,11 +10,11 @@ module.exports = {
   darkMode: 'class',
   theme: {
     fontSize: {
-      'xs': '10px',
-      'sm': '11px',
-      'base': '12px',
-      'lg': '14px',
-      'xl': '16px',
+      xs: '10px',
+      sm: '11px',
+      base: '12px',
+      lg: '14px',
+      xl: '16px',
       '2xl': '18px',
       '3xl': '20px',
       '4xl': '24px',
@@ -22,29 +22,25 @@ module.exports = {
       '6xl': '36px',
     },
     colors: {
-      'charcoal': {
+      charcoal: {
         600: '#27272a',
         800: '#18181b',
       },
-      'gray': {
+      gray: {
         400: '#d1d1d1',
         700: '#aaabac',
         900: '#818181',
       },
-      'purple': {
+      purple: {
         400: '#ad8bfa',
         500: '#8b5cf6',
       },
-      'sky': {
+      sky: {
         400: '#51a2da',
       },
-      'green': {
-        600: '#2b7037',
-      },
-      'red': {
-        600: '#e5421d',
-      },
-      'amber': {
+      green: tailwindColors.green,
+      red: tailwindColors.red,
+      amber: {
         600: tailwindColors.amber[600],
       },
       transparent: 'transparent',
@@ -52,13 +48,11 @@ module.exports = {
       white: '#fff',
       // The remaining colors below are not part of our palette and are only here
       // to maintain existing code. No new use.
-      'violet': {
+      violet: {
         500: tailwindColors.violet[500],
         600: tailwindColors.violet[600],
       },
     },
   },
-  plugins: [
-    tailwindTypography
-  ],
+  plugins: [tailwindTypography],
 };

--- a/packages/shared/src/apis/alternatives-api.ts
+++ b/packages/shared/src/apis/alternatives-api.ts
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 import type { LocalImageAlternative } from '../models/local-image-alternative';
+import type { LocalImageAlternativeReport } from '../models/local-image-alternative-report';
 
 export abstract class AlternativesApi {
   static readonly CHANNEL: string = 'alternatives-api';
@@ -24,4 +25,10 @@ export abstract class AlternativesApi {
    * Get all local images that have Hummingbird alternatives
    */
   abstract getAlternatives(): Promise<Array<LocalImageAlternative>>;
+
+  /**
+   * Given a pair Local Image <-> Hummingbird alternative, get the report
+   * @param alternative
+   */
+  abstract getAlternativeReport(alternative: LocalImageAlternative): Promise<LocalImageAlternativeReport>;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export * from './models/provider-container-connection-identifier-info';
 export * from './models/provider-container-connection-detailed-info';
 export * from './models/simple-image-info';
 export * from './models/local-image-alternative';
+export * from './models/local-image-alternative-report';
 
 // hummingbird project types
 export * from './generated/hummingbird-project';

--- a/packages/shared/src/messages/constants.ts
+++ b/packages/shared/src/messages/constants.ts
@@ -17,5 +17,9 @@
  ***********************************************************************/
 import { getChannel } from './utils';
 import { ImageApi } from '../apis/image-api';
+import { AlternativesApi } from '../apis/alternatives-api';
 
-export const noTimeoutChannels: string[] = [getChannel(ImageApi, 'pull')];
+export const noTimeoutChannels: string[] = [
+  getChannel(ImageApi, 'pull'),
+  getChannel(AlternativesApi, 'getAlternativeReport'),
+];

--- a/packages/shared/src/models/local-image-alternative-report.ts
+++ b/packages/shared/src/models/local-image-alternative-report.ts
@@ -1,0 +1,10 @@
+import type { VulnerabilitiesSummary } from '../generated/hummingbird-project';
+
+export interface LocalImageAlternativeReport {
+  localImage: {
+    vulnerabilities: VulnerabilitiesSummary;
+  };
+  alternative: {
+    vulnerabilities: VulnerabilitiesSummary;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ importers:
         specifier: workspace:^
         version: link:../shared
       '@podman-desktop/grype-extension-api':
-        specifier: ^0.1.0-next.202603121655-ba645db
-        version: 0.1.0-next.202603121655-ba645db
+        specifier: ^0.1.0-next.202604011405-f6be4bb
+        version: 0.1.0-next.202604011405-f6be4bb
       '@podman-desktop/podman-extension-api':
         specifier: ^1.26.1
         version: 1.26.1
@@ -207,7 +207,7 @@ importers:
         version: 5.55.2
       svelte-check:
         specifier: ^4.4.6
-        version: 4.4.6(picomatch@4.0.4)(svelte@5.55.2)(typescript@5.9.3)
+        version: 4.4.6(picomatch@4.0.3)(svelte@5.55.2)(typescript@5.9.3)
       svelte-fa:
         specifier: ^4.0.4
         version: 4.0.4(svelte@5.55.2)
@@ -825,8 +825,8 @@ packages:
   '@podman-desktop/api@1.26.1':
     resolution: {integrity: sha512-mp6+UgOY/lzAy6ieeyWL9xPEdYiYEig5a5vLbmDFZu7/y/uihvxUQQ75VGZQeq37I2xpDztll95fY/NdypoZ1w==}
 
-  '@podman-desktop/grype-extension-api@0.1.0-next.202603121655-ba645db':
-    resolution: {integrity: sha512-4JR4pOv9I1jHIHh5bXO8YSsDQ6IJAmbv8QBQ9lakyG9ZVwebPqyjuAgSKrPs3kjBlxUrsUCXBL7A0UsnjJuRBA==}
+  '@podman-desktop/grype-extension-api@0.1.0-next.202604011405-f6be4bb':
+    resolution: {integrity: sha512-xQsDP8zDUCwjg7TFA/ZYqmS4pwA3lHKNRq7b01lBWaFwYokXRZCdN5+bvIt/Mxt58/wHzFN8ja+drXRHOk3kAw==}
 
   '@podman-desktop/podman-extension-api@1.26.1':
     resolution: {integrity: sha512-OUj+f3WVHdU602hn2OKXEbSTSM4VLR4rL1a4qBAWf2H8I/KrKJmPPDopKd0/pUeeSyUfElyfwAERrHHYDVjU7w==}
@@ -4595,7 +4595,7 @@ snapshots:
 
   '@podman-desktop/api@1.26.1': {}
 
-  '@podman-desktop/grype-extension-api@0.1.0-next.202603121655-ba645db':
+  '@podman-desktop/grype-extension-api@0.1.0-next.202604011405-f6be4bb':
     dependencies:
       zod: 4.3.6
 
@@ -7435,11 +7435,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.2)(typescript@5.9.3):
+  svelte-check@4.4.6(picomatch@4.0.3)(svelte@5.55.2)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
-      fdir: 6.5.0(picomatch@4.0.4)
+      fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.55.2


### PR DESCRIPTION
## Description

In the Alternative table, we want to have information about CVEs and size reduction. This PR is about the first one, to be able to get the data, we need to ask the Grype extension to scan the images. As this operation is expensive we should only do 2 at the time (introducing the `PromiseQueue` class to manage this behavior).

## Screenshots

https://github.com/user-attachments/assets/22413ec1-4f78-42aa-be04-818ec324e8fd

<img width="1414" height="812" alt="image" src="https://github.com/user-attachments/assets/41b212ab-e821-4964-9c46-53c9168d61e0" />


## Related issues

Part of https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/182

**Testing**

> :information_source:  You need to have the grype extension installed 
> You can install it by going to `Extensions > Catalog >Grype`


1. Checkout this branch
2. Start Podman Desktop with `--extension-folder` pointing to `packages/backend`
3. Go to Hummingbird webview
4. Go to `Alternatives` nav section 
5. Assert table is visible
6. If you have no image locally you can pull `docker.io/library/nginx`
7. Hummingbird should detect `docker.io/library/nginx` to have nginx as Hummingbird alternative