### PR TITLE
feat: report details page

### DIFF
--- a/packages/backend/src/apis/alternatives-api-impl.ts
+++ b/packages/backend/src/apis/alternatives-api-impl.ts
@@ -20,6 +20,7 @@ import {
   ImageSummary,
   LocalImageAlternative,
   LocalImageAlternativeReport,
+  OptimisationReport,
 } from '@podman-desktop/extension-hummingbird-core-api';
 import { inject, injectable } from 'inversify';
 import { AlternativeService } from '../services/alternative-service';
@@ -43,5 +44,9 @@ export class AlternativesApiImpl extends AlternativesApi {
 
   override getAlternativeReport(alternative: LocalImageAlternative): Promise<LocalImageAlternativeReport> {
     return this.alternativeService.getAlternativeReport(alternative);
+  }
+
+  override async getOptimisationReport(engineId: string, imageId: string): Promise<OptimisationReport> {
+    return this.alternativeService.getOptimisationReport(engineId, imageId);
   }
 }

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -21,6 +21,7 @@ import {
   CancellationTokenSource,
   containerEngine as containerEngineAPI,
   Disposable,
+  ImageInspectInfo,
   TelemetryLogger,
 } from '@podman-desktop/api';
 import { HummingbirdService } from './hummingbird-service';
@@ -29,6 +30,10 @@ import type {
   LocalImageAlternativeReport,
   LocalContainer,
   ImageSummary,
+  OptimisationReport,
+  VulnerabilitiesSummary,
+  AlternativeReport,
+  SBOMReport,
 } from '@podman-desktop/extension-hummingbird-core-api';
 import alt from '../assets/alt.json' with { type: 'json' };
 import { GrypeService } from './scanners/grype-service';
@@ -189,6 +194,78 @@ export class AlternativeService implements Disposable {
         vulnerabilities: altVulnerabilities,
         size: tag.sizes[localImage.architecture] ?? NaN,
       },
+    };
+  }
+
+  protected async getSBOMReport(image: ImageInspectInfo): Promise<SBOMReport | undefined> {
+    if (!this.grypeService.api) return undefined;
+
+    const doc = await this.grypeService.api.sbom.analyse(
+      {
+        engineId: image.engineId,
+        Id: image.Id,
+      },
+      {
+        task: {
+          title: `Analysing image ${image.RepoTags[0] ?? image.Id}`,
+        },
+      },
+    );
+
+    return {
+      count: doc.artifacts.length,
+      packages: doc.artifacts.map(artifact => artifact.name),
+    };
+  }
+
+  protected async findAlternative(imageInspect: ImageInspectInfo): Promise<AlternativeReport> {
+    const alternative = await this.getAlternative(imageInspect.engineId, imageInspect.Id);
+
+    const imageSummary = await this.hummingbirdService.getImage(alternative.name);
+    const tags = await this.hummingbirdService.getTags(alternative.name);
+    const vulnerabilities = await this.hummingbirdService.getVulnerabilities(alternative.name, imageSummary.latest_tag);
+    const sbom = await this.hummingbirdService.getSbom(alternative.name, imageSummary.latest_tag);
+
+    return {
+      image: imageSummary,
+      sbom: sbom[imageInspect.Architecture],
+      tags: tags,
+      vulnerabilities,
+    };
+  }
+
+  protected async findVulnerabilities(image: ImageInspectInfo): Promise<VulnerabilitiesSummary | undefined> {
+    if (!this.grypeService.isInstalled()) return undefined;
+
+    const doc = await this.grypeService.api.vulnerability.analyse(
+      {
+        engineId: image.engineId,
+        Id: image.Id,
+      },
+      {
+        task: {
+          title: `Scanning image ${image.RepoTags[0] ?? image.Id} for vulnerabilities`,
+        },
+      },
+    );
+
+    return this.grypeService.toVulnerabilitySummary(doc);
+  }
+
+  public async getOptimisationReport(engineId: string, imageId: string): Promise<OptimisationReport> {
+    const imageInspectInfo = await containerEngineAPI.getImageInspect(engineId, imageId);
+
+    const alternative = await this.findAlternative(imageInspectInfo);
+    const sbom = await this.getSBOMReport(imageInspectInfo);
+    const vulnerabilities = await this.findVulnerabilities(imageInspectInfo);
+
+    return {
+      image: {
+        inspect: imageInspectInfo,
+        sbom,
+        vulnerabilities,
+      },
+      alternative: alternative,
     };
   }
 

--- a/packages/backend/src/services/hummingbird-service.ts
+++ b/packages/backend/src/services/hummingbird-service.ts
@@ -15,8 +15,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { Disposable } from '@podman-desktop/api';
-import type { ImageSummary, Tag, VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-core-api';
+import { Disposable } from '@podman-desktop/api';
+import type {
+  ImageSummary,
+  Tag,
+  VulnerabilitiesSummary,
+  VulnerabilitiesResponse,
+  ArchSbom,
+} from '@podman-desktop/extension-hummingbird-core-api';
 import { Api } from '@podman-desktop/extension-hummingbird-core-api';
 import { injectable, preDestroy } from 'inversify';
 
@@ -49,6 +55,22 @@ export class HummingbirdService implements Disposable {
     const res = await this.#client.v1.getTags(image);
     return res.data.tags;
   }
+
+  public async getImage(image: string): Promise<ImageSummary> {
+    const { data: imageSummary } = await this.#client.v1.getImage(image);
+    return imageSummary;
+  }
+
+  public async getVulnerabilities(name: string, tag: string): Promise<VulnerabilitiesResponse> {
+    const { data: vulnerabilities } = await this.#client.v1.getVulnerabilities(name, tag);
+    return vulnerabilities;
+  }
+
+  public async getSbom(name: string, tag: string): Promise<Partial<Record<string, ArchSbom>>> {
+    const { data: sbom } = await this.#client.v1.getSbom(name, tag);
+    return sbom;
+  }
+
   @preDestroy()
   dispose(): void {}
 }

--- a/packages/backend/src/services/scanners/grype-service.ts
+++ b/packages/backend/src/services/scanners/grype-service.ts
@@ -34,6 +34,18 @@ export class GrypeService implements AsyncInit, Disposable {
     return this.#api;
   }
 
+  public isInstalled(): boolean {
+    try {
+      if (this.api) {
+        return true;
+      }
+      // eslint-disable-next-line sonarjs/no-ignored-exceptions
+    } catch (_: unknown) {
+      return false;
+    }
+    return false;
+  }
+
   dispose(): void {
     this.#api = undefined;
   }

--- a/packages/frontend/src/lib/icons/RepositoryIcon.svelte
+++ b/packages/frontend/src/lib/icons/RepositoryIcon.svelte
@@ -1,5 +1,13 @@
-<script>
+<script lang="ts">
 import { colorScheme } from '/@/states/color-scheme.svelte';
+import type { ClassValue } from 'svelte/elements';
+
+interface Props {
+  size?: number;
+  class?: ClassValue;
+}
+
+let { size = 20, class: classes }: Props = $props();
 
 let isDark = $derived(colorScheme.theme === 'dark');
 
@@ -8,7 +16,7 @@ let shieldColor = $derived(isDark ? '#6A4AB2' : '#7E44FF');
 let containerColor = $derived(isDark ? '#B393FA' : '#7E44FF');
 </script>
 
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg class={classes} width={size} height={size} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
   <path
     fill={shieldColor}
     fill-opacity={shieldOpacity}

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
@@ -25,6 +25,7 @@ import ActionColumn from './ActionColumn.svelte';
 import type { LocalImageAlternativeReport } from '@podman-desktop/extension-hummingbird-core-api';
 import type { AlternativeRow } from '/@/routes/alternatives/(components)/row';
 import { goto } from '$app/navigation';
+import { IMAGE_QUERY_KEY } from '/@/routes/images/[engineId]/[imageId]/report/constants';
 
 vi.mock(import('$app/navigation'));
 
@@ -95,7 +96,9 @@ test('should navigate to image report when info button is clicked', async () => 
   const button = getByTitle('Open Image Report Details');
   await fireEvent.click(button);
 
-  expect(goto).toHaveBeenCalledWith('/images/podman/sha256:abc123/report');
+  expect(goto).toHaveBeenCalledWith(
+    `/images/podman/sha256:abc123/report?${IMAGE_QUERY_KEY}=${alternativeRow.localImage.name}`,
+  );
 });
 
 test('should navigate to clone container when clone button is clicked', async () => {

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
@@ -5,6 +5,7 @@ import { faClone } from '@fortawesome/free-solid-svg-icons/faClone';
 import ListItemButtonIcon from '$lib/buttons/ListItemButtonIcon.svelte';
 import { resolve } from '$app/paths';
 import { goto } from '$app/navigation';
+import { IMAGE_QUERY_KEY } from '/@/routes/images/[engineId]/[imageId]/report/constants';
 
 interface Props {
   object: Row;
@@ -12,9 +13,13 @@ interface Props {
 
 let { object }: Props = $props();
 
-function onOpenImageReport(engineId: string, imageId: string): Promise<void> {
+async function onOpenImageReport(engineId: string, imageId: string): Promise<void> {
+  if (!('report' in object)) {
+    return;
+  }
+
   return goto(
-    resolve('/images/[engineId]/[imageId]/report', {
+    resolve(`/images/[engineId]/[imageId]/report?${IMAGE_QUERY_KEY}=${encodeURIComponent(object.localImage.name)}`, {
       engineId: engineId,
       imageId: imageId,
     }),
@@ -23,7 +28,7 @@ function onOpenImageReport(engineId: string, imageId: string): Promise<void> {
 
 function onCloneContainer(engineId: string, containerId: string): Promise<void> {
   return goto(
-    resolve('/containers/[engineId]/[id]/clone', {
+    resolve(`/containers/[engineId]/[id]/clone`, {
       engineId: engineId,
       id: containerId,
     }),

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.spec.ts
@@ -1,0 +1,70 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import OptimisationReport from './OptimisationReport.svelte';
+import type { OptimisationReport as OptimisationReportType } from '@podman-desktop/extension-hummingbird-core-api';
+
+test('Expect that OptimisationReport displays RawReport when alternative is present', async () => {
+  const object = {
+    image: {
+      inspect: {
+        RepoTags: ['original-image:latest'],
+        Size: 100000000,
+        Architecture: 'amd64',
+        Created: '2024-01-01T00:00:00Z',
+      },
+      vulnerabilities: { total: 20, critical: 2, high: 4, medium: 8, low: 6 },
+    },
+    alternative: {
+      image: {
+        name: 'alt-image',
+        latest_tag: '1.0.0',
+      },
+      tags: [{ name: '1.0.0', sizes: { amd64: 50000000 } }],
+      vulnerabilities: {
+        summary: { total: 5, critical: 0, high: 1, medium: 2, low: 2 },
+      },
+    },
+  };
+
+  render(OptimisationReport, { object: object as unknown as OptimisationReportType });
+
+  expect(screen.getByText('alt-image')).toBeInTheDocument();
+});
+
+test('Expect that OptimisationReport displays empty screen when no alternative is present', async () => {
+  const object = {
+    image: {
+      inspect: {
+        RepoTags: ['original-image:latest'],
+        Size: 100000000,
+        Architecture: 'amd64',
+        Created: '2024-01-01T00:00:00Z',
+      },
+      vulnerabilities: { total: 20 },
+    },
+    alternative: undefined,
+  };
+
+  render(OptimisationReport, { object: object as unknown as OptimisationReportType });
+
+  expect(screen.getByText('No alternative image found')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+import type { OptimisationReport } from '@podman-desktop/extension-hummingbird-core-api';
+import { SvelteSet } from 'svelte/reactivity';
+import RawReport from '/@/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.svelte';
+import { EmptyScreen } from '@podman-desktop/ui-svelte';
+import { faShieldHalved } from '@fortawesome/free-solid-svg-icons/faShieldHalved';
+
+interface Props {
+  object: OptimisationReport;
+}
+
+let { object }: Props = $props();
+
+const imagePkgs = $derived(new SvelteSet(object.image.sbom?.packages ?? []));
+const altPkgs = $derived(new SvelteSet(object.alternative?.sbom?.packages?.map(p => p.name) ?? []));
+
+const allPkgs = $derived(Array.from(new Set([...imagePkgs, ...altPkgs])).sort((a, b) => a.localeCompare(b)));
+</script>
+
+{#if object.alternative}
+  <RawReport alternative={object.alternative} image={object.image} />
+{:else}
+  <EmptyScreen icon={faShieldHalved} title="No alternative image found" message="No alternative image found." />
+{/if}

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import RawReport from './RawReport.svelte';
+import type { AlternativeReport, ImageReport } from '@podman-desktop/extension-hummingbird-core-api';
+
+test('Expect that RawReport displays both image cards', async () => {
+  const alternative = {
+    image: {
+      name: 'alt-image',
+      latest_tag: '1.0.0',
+    },
+    tags: [{ name: '1.0.0', sizes: { amd64: 50000000 } }],
+    vulnerabilities: {
+      summary: { total: 5, critical: 0, high: 1, medium: 2, low: 2 },
+    },
+  };
+
+  const image = {
+    inspect: {
+      RepoTags: ['original-image:latest'],
+      Size: 100000000,
+      Architecture: 'amd64',
+      Created: '2024-01-01T00:00:00Z',
+    },
+    vulnerabilities: { total: 20, critical: 2, high: 4, medium: 8, low: 6 },
+  };
+
+  render(RawReport, {
+    alternative: alternative as unknown as AlternativeReport,
+    image: image as unknown as ImageReport,
+  });
+
+  expect(screen.getByText('alt-image')).toBeInTheDocument();
+  expect(screen.getByText('original-image:latest')).toBeInTheDocument();
+  expect(screen.getByText('Hardened Alternative Found!')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+import { TableDurationColumn } from '@podman-desktop/ui-svelte';
+import { filesize } from 'filesize';
+import type { AlternativeReport, ImageReport, Tag } from '@podman-desktop/extension-hummingbird-core-api';
+
+import ReportBanner from './ReportBanner.svelte';
+import ReportImageCard from './ReportImageCard.svelte';
+import ReportComparison from './ReportComparison.svelte';
+
+interface Props {
+  alternative: AlternativeReport;
+  image: ImageReport;
+}
+
+let { alternative, image }: Props = $props();
+
+let tag: Tag | undefined = $derived.by(() => {
+  return alternative.tags.find(t => t.name === alternative.image.latest_tag);
+});
+
+let cveReduction: { count: number; percent: number } | undefined = $derived.by(() => {
+  if (!image.vulnerabilities || !alternative.vulnerabilities?.summary) return undefined;
+
+  const imageTotal = image.vulnerabilities.total;
+  const altTotal = alternative.vulnerabilities.summary.total;
+
+  if (imageTotal < altTotal) return undefined;
+
+  return {
+    count: imageTotal - altTotal,
+    percent: imageTotal > 0 ? 100 - (altTotal / imageTotal) * 100 : 0,
+  };
+});
+
+let altSize: number = $derived(tag?.sizes?.[image.inspect.Architecture] ?? 0);
+let sizeReductionPercent: number = $derived.by(() => {
+  if (!altSize || !image.inspect.Size) return 0;
+  return 100 - (altSize / image.inspect.Size) * 100;
+});
+
+const altRepoTag = $derived(alternative.image.name);
+const imageRepoTag = $derived(image.inspect?.RepoTags?.[0] ?? 'Unknown');
+const imageVersion = $derived(imageRepoTag.split(':')[1] ?? '-');
+</script>
+
+<div class="flex flex-col gap-5 overflow-auto">
+  <!-- Alternate Image Found Banner -->
+  <ReportBanner
+    cveReductionCount={cveReduction?.count}
+    cveReductionPercent={cveReduction?.percent}
+    sizeReductionPercent={sizeReductionPercent} />
+
+  <!-- Side by Side Cards -->
+  <div class="grid grid-cols-2 gap-5">
+    <!-- Hummingbird Card -->
+    <ReportImageCard
+      isHummingbird={true}
+      title={altRepoTag}
+      subtitle="Hummingbird hardened image"
+      version={alternative.image.latest_tag}
+      vulnerabilities={alternative.vulnerabilities.summary}
+      vulnerabilitiesReduction={cveReduction?.count}
+      size={filesize(altSize)}
+      sizeReductionPercent={sizeReductionPercent}
+      date={alternative.image.oldest_created ?? undefined}>
+      {#snippet dateDisplay()}
+        {#if alternative.image.oldest_created}
+          <TableDurationColumn object={new Date(alternative.image.oldest_created)} />
+        {:else}
+          —
+        {/if}
+      {/snippet}
+    </ReportImageCard>
+
+    <!-- Current Image Card -->
+    <ReportImageCard
+      title={imageRepoTag}
+      subtitle="Current image"
+      version={imageVersion}
+      vulnerabilities={image.vulnerabilities}
+      size={filesize(image.inspect.Size)}
+      date={image.inspect.Created}
+      dateLabel="Created" />
+  </div>
+
+  <!-- Try the Alternate Base Image - Combined Section -->
+  <ReportComparison
+    cveReductionPercent={cveReduction?.percent}
+    sizeReductionPercent={sizeReductionPercent}
+    altCveCount={alternative.vulnerabilities.summary.total}
+    imageCveCount={image.vulnerabilities?.total}
+    altSize={altSize}
+    imageSize={image.inspect.Size} />
+</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.spec.ts
@@ -1,0 +1,44 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import ReportBanner from './ReportBanner.svelte';
+
+test('Expect that ReportBanner displays CVE reduction and size reduction info', async () => {
+  render(ReportBanner, {
+    cveReductionCount: 15,
+    cveReductionPercent: 75,
+    sizeReductionPercent: 40,
+  });
+
+  expect(screen.getByText('-15')).toBeInTheDocument();
+  expect(screen.getByText('75%')).toBeInTheDocument();
+  expect(screen.getByText('-40%')).toBeInTheDocument();
+  expect(screen.getByText('Hardened Alternative Found!')).toBeInTheDocument();
+});
+
+test('Expect that ReportBanner does not display CVE info when not provided', async () => {
+  render(ReportBanner, {
+    sizeReductionPercent: 40,
+  });
+
+  expect(screen.queryByText('CVEs')).not.toBeInTheDocument();
+  expect(screen.getByText('-40%')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+import RepositoryIcon from '$lib/icons/RepositoryIcon.svelte';
+
+interface Props {
+  cveReductionCount?: number;
+  cveReductionPercent?: number;
+  sizeReductionPercent?: number;
+}
+
+let { cveReductionCount, cveReductionPercent, sizeReductionPercent }: Props = $props();
+</script>
+
+<div class="bg-purple-500/20 border border-purple-500/40 rounded-lg px-4 py-2">
+  <div class="flex items-center justify-between">
+    <div class="flex items-center gap-4">
+      <div
+        class="w-14 h-14 bg-purple-500/30 rounded-full flex items-center justify-center border-2 border-purple-400/50">
+        <RepositoryIcon size={24} />
+      </div>
+      <div class="flex flex-col">
+        <span class="text-lg font-bold text-purple-300">Hardened Alternative Found!</span>
+        <span class="text-sm text-[var(--pd-content-text)] opacity-70"
+          >A Hummingbird image is available with significant security improvements</span>
+      </div>
+    </div>
+    <div class="flex items-center gap-8 bg-[var(--pd-content-card-bg)]/50 rounded-lg px-6 py-3">
+      {#if cveReductionCount !== undefined && cveReductionPercent !== undefined}
+        <!-- CVEs -->
+        <div class="text-center">
+          <div class="text-3xl font-bold text-purple-300">-{cveReductionCount}</div>
+          <div class="text-xs text-[var(--pd-content-text)] opacity-60">CVEs</div>
+        </div>
+
+        <!-- CVE Reduction % -->
+        <div class="text-center">
+          <div class="text-3xl font-bold text-purple-300">{cveReductionPercent.toFixed(0)}%</div>
+          <div class="text-xs text-[var(--pd-content-text)] opacity-60">Fewer CVEs</div>
+        </div>
+      {/if}
+
+      {#if sizeReductionPercent !== undefined}
+        <!-- Size Reduction -->
+        <div class="text-center">
+          <div class="text-3xl font-bold text-purple-300">-{sizeReductionPercent.toFixed(0)}%</div>
+          <div class="text-xs text-[var(--pd-content-text)] opacity-60">Smaller Size</div>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.spec.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import ReportComparison from './ReportComparison.svelte';
+
+test('Expect that ReportComparison displays comparison info', async () => {
+  render(ReportComparison, {
+    cveReductionPercent: 75,
+    sizeReductionPercent: 40,
+    altCveCount: 5,
+    imageCveCount: 20,
+    altSize: 60 * 1024 * 1024,
+    imageSize: 100 * 1024 * 1024,
+  });
+
+  expect(screen.getByText('75% Fewer Vulnerabilities')).toBeInTheDocument();
+  expect(screen.getByText('40% Smaller Image Size')).toBeInTheDocument();
+  expect(screen.getByText('Only 5 CVE vs 20')).toBeInTheDocument();
+  expect(screen.getByText('Try the Alternate Base Image')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+import { filesize } from 'filesize';
+import RepositoryIcon from '$lib/icons/RepositoryIcon.svelte';
+
+interface Props {
+  cveReductionPercent?: number;
+  sizeReductionPercent?: number;
+  altCveCount?: number;
+  imageCveCount?: number;
+  altSize?: number;
+  imageSize?: number;
+}
+
+let { cveReductionPercent, sizeReductionPercent, altCveCount, imageCveCount, altSize, imageSize }: Props = $props();
+
+const benefits = [
+  {
+    title: `${cveReductionPercent?.toFixed(0) ?? 0}% Fewer Vulnerabilities`,
+    description: `Only ${altCveCount ?? 0} CVE vs ${imageCveCount ?? 0}`,
+    show: cveReductionPercent !== undefined,
+  },
+  {
+    title: `${sizeReductionPercent?.toFixed(0) ?? 0}% Smaller Image Size`,
+    description: `${filesize(altSize ?? 0)} vs ${filesize(imageSize ?? 0)}`,
+    show: sizeReductionPercent !== undefined,
+  },
+  {
+    title: 'Enterprise-Grade Security',
+    description: 'FIPS-compliant with continuous scanning',
+    show: true,
+  },
+  {
+    title: 'Minimal Attack Surface',
+    description: 'Distroless with essential components only',
+    show: true,
+  },
+];
+</script>
+
+<div class="bg-[var(--pd-content-card-bg)] rounded-lg border border-[var(--pd-content-card-border)] p-5">
+  <!-- Header -->
+  <div class="flex items-center gap-3 mb-3">
+    <div class="w-9 h-9 bg-purple-500/20 rounded-lg flex items-center justify-center">
+      <RepositoryIcon size={24} />
+    </div>
+    <div>
+      <span class="text-base font-bold text-[var(--pd-content-header)]">Try the Alternate Base Image</span>
+      <p class="text-xs text-[var(--pd-content-text)] opacity-70">
+        Switch to Hummingbird for enhanced security and performance
+      </p>
+    </div>
+  </div>
+
+  <!-- Two Column Layout -->
+  <div class="grid grid-cols-2 gap-6 mt-4">
+    <!-- Left: Benefits List -->
+    <div class="space-y-3">
+      {#each benefits.filter(b => b.show) as benefit (benefit.title)}
+        <div class="flex items-start gap-2">
+          <div class="w-4 h-4 rounded-full bg-green-500/20 flex items-center justify-center flex-shrink-0 mt-0.5">
+            <svg class="w-2.5 h-2.5 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fill-rule="evenodd"
+                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                clip-rule="evenodd"></path>
+            </svg>
+          </div>
+          <div>
+            <span class="text-xs font-semibold text-[var(--pd-content-header)]">{benefit.title}</span>
+            <p class="text-[10px] text-[var(--pd-content-text)] opacity-60">{benefit.description}</p>
+          </div>
+        </div>
+      {/each}
+    </div>
+
+    <!-- Right: Evaluation Criteria -->
+    <div class="space-y-3">
+      <!-- Image Size Comparison -->
+      {#if sizeReductionPercent !== undefined && altSize !== undefined && imageSize !== undefined}
+        <div>
+          <div class="flex justify-between items-center mb-1">
+            <span class="text-xs text-[var(--pd-content-text)]">Image Size</span>
+            <span class="text-xs font-semibold text-purple-400">-{sizeReductionPercent.toFixed(0)}%</span>
+          </div>
+          <div class="space-y-1">
+            <div
+              class="h-5 rounded bg-purple-500/40 flex items-center px-2"
+              style="width: {Math.max(10, 100 - sizeReductionPercent)}%">
+              <span class="text-[10px] line-clamp-1 font-medium text-purple-200">{filesize(altSize)}</span>
+            </div>
+            <div class="h-5 rounded bg-purple-500/20 flex items-center px-2" style="width: 100%">
+              <span class="text-[10px] font-medium text-purple-200/60">{filesize(imageSize)}</span>
+            </div>
+          </div>
+        </div>
+      {/if}
+
+      <!-- CVE Count Comparison -->
+      {#if cveReductionPercent !== undefined && altCveCount !== undefined && imageCveCount !== undefined}
+        <div>
+          <div class="flex justify-between items-center mb-1">
+            <span class="text-xs text-[var(--pd-content-text)]">CVE Count</span>
+            <span class="text-xs font-semibold text-purple-400">-{cveReductionPercent.toFixed(0)}%</span>
+          </div>
+          <div class="space-y-1">
+            <div
+              class="h-5 rounded bg-purple-500/40 flex items-center px-2"
+              style="width: {Math.max(10, 100 - cveReductionPercent)}%">
+              <span class="text-[10px] font-medium text-purple-200">{altCveCount}</span>
+            </div>
+            <div class="h-5 rounded bg-purple-500/20 flex items-center px-2" style="width: 100%">
+              <span class="text-[10px] font-medium text-purple-200/60">{imageCveCount}</span>
+            </div>
+          </div>
+        </div>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.spec.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import ReportImageCard from './ReportImageCard.svelte';
+
+test('Expect that ReportImageCard displays basic info', async () => {
+  render(ReportImageCard, {
+    title: 'test-image',
+    subtitle: 'test-subtitle',
+    version: '1.2.3',
+    size: '100 MB',
+  });
+
+  expect(screen.getByText('test-image')).toBeInTheDocument();
+  expect(screen.getByText('test-subtitle')).toBeInTheDocument();
+  expect(screen.getByText('1.2.3')).toBeInTheDocument();
+  expect(screen.getByText('100 MB')).toBeInTheDocument();
+});
+
+test('Expect that ReportImageCard displays reduction info for Hummingbird', async () => {
+  render(ReportImageCard, {
+    title: 'hummingbird-image',
+    subtitle: 'Hummingbird hardened image',
+    version: 'latest',
+    size: '60 MB',
+    sizeReductionPercent: 40,
+    isHummingbird: true,
+  });
+
+  expect(screen.getByText('(-40%)')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+import type { VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-core-api';
+import VulnerabilitySummary from './VulnerabilitySummary.svelte';
+import type { Snippet } from 'svelte';
+import RepositoryIcon from '$lib/icons/RepositoryIcon.svelte';
+
+interface Props {
+  title: string;
+  subtitle: string;
+  version: string;
+  vulnerabilities?: VulnerabilitiesSummary;
+  vulnerabilitiesReduction?: number;
+  size: string;
+  sizeReductionPercent?: number;
+  isHummingbird?: boolean;
+  date?: string | Date;
+  dateLabel?: string;
+  dateDisplay?: Snippet;
+}
+
+let {
+  title,
+  subtitle,
+  version,
+  vulnerabilities,
+  vulnerabilitiesReduction,
+  size,
+  sizeReductionPercent,
+  isHummingbird = false,
+  date,
+  dateLabel = 'Last Updated',
+  dateDisplay,
+}: Props = $props();
+</script>
+
+<div
+  class="bg-[var(--pd-content-card-bg)] rounded-lg border {isHummingbird
+    ? 'border-purple-500/30'
+    : 'border-[var(--pd-content-card-border)]'} p-5">
+  <!-- Header -->
+  <div class="flex items-center gap-3 mb-4">
+    <RepositoryIcon
+      class={[...(isHummingbird ? ['text-purple-400'] : ['text-[var(--pd-content-text)] grayscale'])]}
+      size={24} />
+    <div class="min-w-0 flex-1">
+      <span class="text-base font-bold text-[var(--pd-content-header)] block truncate" title={title}>{title}</span>
+      <span class="text-xs {isHummingbird ? 'text-purple-400' : 'text-[var(--pd-content-text)] opacity-50'} block"
+        >{subtitle}</span>
+    </div>
+  </div>
+
+  <!-- Metadata List -->
+  <div class="space-y-3">
+    <!-- Version Row -->
+    <div class="flex justify-between items-center">
+      <span class="text-xs text-[var(--pd-content-text)] opacity-50 uppercase tracking-wide">Version</span>
+      <span class="text-sm font-mono {isHummingbird ? 'text-purple-400' : 'text-[var(--pd-content-header)]'}"
+        >{version}</span>
+    </div>
+
+    <!-- Vulnerabilities Row -->
+    <div class="flex justify-between items-center">
+      <span class="text-xs text-[var(--pd-content-text)] opacity-50 uppercase tracking-wide">Vulnerabilities</span>
+      <VulnerabilitySummary
+        vulnerabilities={vulnerabilities}
+        reduction={vulnerabilitiesReduction}
+        showReduction={isHummingbird} />
+    </div>
+
+    <!-- Size Row -->
+    <div class="flex justify-between items-center">
+      <span class="text-xs text-[var(--pd-content-text)] opacity-50 uppercase tracking-wide">Size</span>
+      <span class="text-sm text-[var(--pd-content-header)]">
+        {size}
+        {#if isHummingbird && sizeReductionPercent !== undefined}
+          <span class="text-xs text-purple-400 font-medium">(-{sizeReductionPercent.toFixed(0)}%)</span>
+        {/if}
+      </span>
+    </div>
+
+    <!-- Date Row -->
+    <div class="flex justify-between items-center">
+      <span class="text-xs text-[var(--pd-content-text)] opacity-50 uppercase tracking-wide">{dateLabel}</span>
+      <span class="text-sm text-[var(--pd-content-header)]">
+        {#if dateDisplay}
+          {@render dateDisplay()}
+        {:else if date}
+          {new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}
+        {:else}
+          —
+        {/if}
+      </span>
+    </div>
+  </div>
+</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/VulnerabilitySummary.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/VulnerabilitySummary.spec.ts
@@ -1,0 +1,58 @@
+/**********************************************************************
+ * Copyright (C) 2024 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import VulnerabilitySummary from './VulnerabilitySummary.svelte';
+import type { VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-core-api';
+
+test('Expect that VulnerabilitySummary displays vulnerability counts', async () => {
+  const vulnerabilities = {
+    critical: 1,
+    high: 2,
+    medium: 3,
+    low: 4,
+    total: 10,
+  };
+
+  render(VulnerabilitySummary, { vulnerabilities: vulnerabilities as unknown as VulnerabilitiesSummary });
+
+  expect(screen.getByTitle('Critical')).toHaveTextContent('1');
+  expect(screen.getByTitle('High')).toHaveTextContent('2');
+  expect(screen.getByTitle('Medium')).toHaveTextContent('3');
+  expect(screen.getByTitle('Low')).toHaveTextContent('4');
+});
+
+test('Expect that VulnerabilitySummary displays reduction when showReduction is true', async () => {
+  const vulnerabilities = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    total: 0,
+  };
+
+  render(VulnerabilitySummary, {
+    vulnerabilities: vulnerabilities as unknown as VulnerabilitiesSummary,
+    reduction: 5,
+    showReduction: true,
+  });
+
+  expect(screen.getByText('(-5)')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/VulnerabilitySummary.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/VulnerabilitySummary.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import type { VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-core-api';
+
+interface Props {
+  vulnerabilities?: VulnerabilitiesSummary;
+  reduction?: number;
+  showReduction?: boolean;
+  class?: string;
+}
+
+let { vulnerabilities, reduction, showReduction = false, class: className = '' }: Props = $props();
+</script>
+
+<div class="flex items-center gap-2 {className}">
+  <div class="flex items-center gap-1">
+    <span
+      class="w-7 h-6 flex items-center justify-center text-xs font-semibold rounded {vulnerabilities?.critical
+        ? 'bg-red-600 text-white'
+        : 'bg-[var(--pd-content-card-border)] text-[var(--pd-content-text)] opacity-50'}"
+      title="Critical">
+      {vulnerabilities?.critical ?? 0}
+    </span>
+    <span
+      class="w-7 h-6 flex items-center justify-center text-xs font-semibold rounded {vulnerabilities?.high
+        ? 'bg-orange-500 text-white'
+        : 'bg-[var(--pd-content-card-border)] text-[var(--pd-content-text)] opacity-50'}"
+      title="High">
+      {vulnerabilities?.high ?? 0}
+    </span>
+    <span
+      class="w-7 h-6 flex items-center justify-center text-xs font-semibold rounded {vulnerabilities?.medium
+        ? 'bg-amber-400 text-gray-900'
+        : 'bg-[var(--pd-content-card-border)] text-[var(--pd-content-text)] opacity-50'}"
+      title="Medium">
+      {vulnerabilities?.medium ?? 0}
+    </span>
+    <span
+      class="w-7 h-6 flex items-center justify-center text-xs font-semibold rounded {vulnerabilities?.low
+        ? 'bg-yellow-300 text-gray-900'
+        : 'bg-[var(--pd-content-card-border)] text-[var(--pd-content-text)] opacity-50'}"
+      title="Low">
+      {vulnerabilities?.low ?? 0}
+    </span>
+  </div>
+  {#if showReduction && reduction !== undefined}
+    <span class="text-xs text-purple-400 font-medium">(-{reduction})</span>
+  {/if}
+</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.svelte
@@ -1,4 +1,30 @@
 <script lang="ts">
+import type { PageProps } from './$types';
+import OptimisationReport from '/@/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.svelte';
+import { DetailsPage } from '@podman-desktop/ui-svelte';
+import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
+
+let { data }: PageProps = $props();
+
+function close(): Promise<void> {
+  return goto(resolve('/alternatives'));
+}
 </script>
 
-<span>TODO: images report page</span>
+<DetailsPage
+  title={data.image}
+  breadcrumbLeftPart="Alternatives"
+  breadcrumbRightPart={data.image}
+  onbreadcrumbClick={close}
+  onclose={close}>
+  {#snippet contentSnippet()}
+    {#await data.report}
+      <span>Loading...</span>
+    {:then report}
+      <div class="px-5 pt-5 w-full">
+        <OptimisationReport object={report} />
+      </div>
+    {/await}
+  {/snippet}
+</DetailsPage>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.ts
@@ -1,0 +1,38 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+import type { OptimisationReport } from '@podman-desktop/extension-hummingbird-core-api';
+import type { PageLoad } from './$types';
+import { alternativesAPI } from '/@/api/client';
+import { IMAGE_QUERY_KEY } from '/@/routes/images/[engineId]/[imageId]/report/constants';
+
+interface Data {
+  engineId: string;
+  image: string;
+  report: Promise<OptimisationReport>;
+}
+
+export const load: PageLoad = async ({ params, url }): Promise<Data> => {
+  const engineId = decodeURIComponent(params.engineId);
+  const imageId = decodeURIComponent(params.imageId);
+
+  return {
+    engineId,
+    image: url.searchParams.get(IMAGE_QUERY_KEY) ?? '<unknown>',
+    report: alternativesAPI.getOptimisationReport(engineId, imageId),
+  };
+};

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/constants.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/constants.ts
@@ -1,0 +1,19 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+export const IMAGE_QUERY_KEY = 'image';

--- a/packages/frontend/tailwind.config.cjs
+++ b/packages/frontend/tailwind.config.cjs
@@ -40,9 +40,9 @@ module.exports = {
       },
       green: tailwindColors.green,
       red: tailwindColors.red,
-      amber: {
-        600: tailwindColors.amber[600],
-      },
+      amber: tailwindColors.amber,
+      orange: tailwindColors.orange,
+      yellow: tailwindColors.yellow,
       transparent: 'transparent',
       black: '#000',
       white: '#fff',

--- a/packages/shared/src/apis/alternatives-api.ts
+++ b/packages/shared/src/apis/alternatives-api.ts
@@ -18,6 +18,7 @@
 import type { ImageSummary } from '../generated/hummingbird-project';
 import type { LocalImageAlternative } from '../models/local-image-alternative';
 import type { LocalImageAlternativeReport } from '../models/local-image-alternative-report';
+import type { OptimisationReport } from '../models/optimization-report';
 
 export abstract class AlternativesApi {
   static readonly CHANNEL: string = 'alternatives-api';
@@ -34,4 +35,6 @@ export abstract class AlternativesApi {
    * @param alternative
    */
   abstract getAlternativeReport(alternative: LocalImageAlternative): Promise<LocalImageAlternativeReport>;
+
+  abstract getOptimisationReport(engineId: string, imageId: string): Promise<OptimisationReport>;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -39,6 +39,7 @@ export * from './models/simple-image-info';
 export * from './models/local-image-alternative';
 export * from './models/local-image-alternative-report';
 export * from './models/local-container';
+export * from './models/optimization-report';
 
 // hummingbird project types
 export * from './generated/hummingbird-project';

--- a/packages/shared/src/models/optimization-report.ts
+++ b/packages/shared/src/models/optimization-report.ts
@@ -1,0 +1,49 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import type {
+  ArchSbom,
+  ImageSummary,
+  Tag,
+  VulnerabilitiesResponse,
+  VulnerabilitiesSummary,
+} from '../generated/hummingbird-project';
+import type { ImageInspectInfo } from '@podman-desktop/api';
+
+export interface AlternativeReport {
+  image: ImageSummary;
+  sbom?: ArchSbom;
+  tags: Tag[];
+  vulnerabilities: VulnerabilitiesResponse;
+}
+
+export interface SBOMReport {
+  count: number;
+  packages: string[];
+}
+
+export interface ImageReport {
+  inspect: ImageInspectInfo;
+  sbom?: SBOMReport;
+  vulnerabilities?: VulnerabilitiesSummary;
+}
+
+export interface OptimisationReport {
+  image: ImageReport;
+  alternative?: AlternativeReport;
+}


### PR DESCRIPTION
## Description

Adding the report details page.

## Screenshots

<img width="1349" height="900" alt="image" src="https://github.com/user-attachments/assets/5c85c03e-304b-4d07-ab03-d8d4fc9a5d64" />

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/234

## Testing

1. Pull any image with an Hummingbird alternative (E.g. `docker.io/library/postgres:18.3`)
2. Go to `Hummingbird > Alternatives` webview
3.  Click on the (i)
<img width="224" height="102" alt="image" src="https://github.com/user-attachments/assets/2be9888c-0f31-45a2-a498-196596fb0a5e" />

4. Assert you see a nice comparison report between the Hummingbird and the container image