### PR TITLE
feat(alt-table): make it reactive

### DIFF
--- a/__mocks__/@podman-desktop/api.ts
+++ b/__mocks__/@podman-desktop/api.ts
@@ -97,6 +97,7 @@ const plugin = {
     listInfos: vi.fn(),
     listImages: vi.fn(),
     listContainers: vi.fn(),
+    onEvent: vi.fn(),
   } as unknown as typeof podmanDesktopApi.containerEngine,
   configuration: {} as unknown as typeof podmanDesktopApi.configuration,
   authentication: {} as unknown as typeof podmanDesktopApi.authentication,

--- a/packages/backend/src/services/alternative-service.spec.ts
+++ b/packages/backend/src/services/alternative-service.spec.ts
@@ -16,9 +16,9 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
-import { expect, test, vi, beforeEach, describe } from 'vitest';
-import type { TelemetryLogger, ImageInfo } from '@podman-desktop/api';
-import { containerEngine } from '@podman-desktop/api';
+import { expect, test, vi, beforeEach, describe, assert } from 'vitest';
+import type { TelemetryLogger, ImageInfo, Webview, WebviewPanel, ContainerJSONEvent } from '@podman-desktop/api';
+import { containerEngine as containerEngineAPI, containerEngine } from '@podman-desktop/api';
 import { AlternativeService } from './alternative-service';
 import type { HummingbirdService } from './hummingbird-service';
 import type {
@@ -29,6 +29,7 @@ import type {
 } from '@podman-desktop/extension-hummingbird-core-api';
 import type { GrypeService } from './scanners/grype-service';
 import type { grype } from '@podman-desktop/grype-extension-api';
+import type { WebviewService } from '/@/services/webview-service';
 
 const TELEMETRY_LOGGER_MOCK: TelemetryLogger = {
   logUsage: vi.fn(),
@@ -81,14 +82,32 @@ const GRYPE_SERVICE_MOCK: GrypeService = {
   toVulnerabilitySummary: vi.fn(),
 } as unknown as GrypeService;
 
+const WEBVIEW_SERVICE_MOCK: WebviewService = {
+  getPanel: vi.fn(),
+} as unknown as WebviewService;
+
+const WEBVIEW_MOCK: Webview = {
+  postMessage: vi.fn(),
+} as unknown as Webview;
+
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(HUMMINGBIRD_SERVICE_MOCK.getImages).mockResolvedValue(HUMMINGBIRD_IMAGES_MOCK);
   vi.mocked(containerEngine.listContainers).mockResolvedValue([]);
+
+  vi.mocked(WEBVIEW_SERVICE_MOCK.getPanel).mockReturnValue({
+    webview: WEBVIEW_MOCK,
+  } as unknown as WebviewPanel);
+  vi.mocked(WEBVIEW_MOCK.postMessage).mockResolvedValue(true);
 });
 
 function getAlternativeService(): AlternativeService {
-  return new AlternativeService(TELEMETRY_LOGGER_MOCK, HUMMINGBIRD_SERVICE_MOCK, GRYPE_SERVICE_MOCK);
+  return new AlternativeService(
+    TELEMETRY_LOGGER_MOCK,
+    HUMMINGBIRD_SERVICE_MOCK,
+    GRYPE_SERVICE_MOCK,
+    WEBVIEW_SERVICE_MOCK,
+  );
 }
 
 test('should return alternatives for matching local images', async () => {
@@ -376,5 +395,150 @@ describe('AlternativeService#getAlternativeReport', () => {
     const service = getAlternativeService();
 
     await expect(service.getAlternativeReport(mockAlternative)).rejects.toThrowError('Cannot find tag 1.21 for nginx');
+  });
+});
+
+describe('init', () => {
+  test('should register event listeners', async () => {
+    const service = getAlternativeService();
+    await service.init();
+
+    expect(containerEngineAPI.onEvent).toHaveBeenCalledExactlyOnceWith(expect.any(Function));
+  });
+
+  async function getListener(): Promise<(event: ContainerJSONEvent) => void> {
+    const service = getAlternativeService();
+    await service.init();
+
+    const event = vi.mocked(containerEngineAPI.onEvent).mock.calls[0][0];
+    assert(event);
+    return event;
+  }
+
+  interface TestCase {
+    name: string;
+    event: unknown;
+    notified: boolean;
+  }
+
+  test.each<TestCase>([
+    {
+      name: 'pull event for image with alternative should notify',
+      event: {
+        Action: 'pull',
+        Actor: {
+          Attributes: {
+            name: 'docker.io/library/postgres:18.3',
+          },
+        },
+        Type: 'image',
+        id: 'foo',
+      },
+      notified: true,
+    },
+    {
+      name: 'pull event for image without alternative should not notify',
+      event: {
+        Action: 'pull',
+        Actor: {
+          Attributes: {
+            name: 'docker.io/foo/bar:latest',
+          },
+        },
+        Type: 'image',
+        id: 'foo',
+      },
+      notified: false,
+    },
+    {
+      name: 'delete event for image with alternative should notify',
+      event: {
+        Action: 'delete',
+        Actor: {
+          Attributes: {
+            name: 'docker.io/library/postgres:18.3',
+          },
+        },
+        Type: 'image',
+        id: 'foo',
+      },
+      notified: true,
+    },
+    {
+      name: 'delete event for image without alternative should notify',
+      event: {
+        Action: 'delete',
+        Actor: {
+          Attributes: {
+            name: 'docker.io/foo/bar:latest',
+          },
+        },
+        Type: 'image',
+        id: 'foo',
+      },
+      notified: false,
+    },
+    {
+      name: 'remove event for container with alternative should notify',
+      event: {
+        Action: 'remove',
+        Actor: {
+          Attributes: {
+            image: 'docker.io/library/postgres:18.3',
+          },
+        },
+        Type: 'container',
+        id: 'foo',
+      },
+      notified: true,
+    },
+    {
+      name: 'remove event for container without alternative should notify',
+      event: {
+        Action: 'remove',
+        Actor: {
+          Attributes: {
+            image: 'docker.io/foo/bar:latest',
+          },
+        },
+        Type: 'container',
+        id: 'foo',
+      },
+      notified: false,
+    },
+    {
+      name: 'init event for container with alternative should notify',
+      event: {
+        Action: 'init',
+        Actor: {
+          Attributes: {
+            image: 'docker.io/library/postgres:18.3',
+          },
+        },
+        Type: 'container',
+        id: 'foo',
+      },
+      notified: true,
+    },
+    {
+      name: 'init event for container without alternative should notify',
+      event: {
+        Action: 'init',
+        Actor: {
+          Attributes: {
+            image: 'docker.io/foo/bar:latest',
+          },
+        },
+        Type: 'container',
+        id: 'foo',
+      },
+      notified: false,
+    },
+  ])('$name', async ({ event, notified }) => {
+    const listener = await getListener();
+
+    listener(event as unknown as ContainerJSONEvent);
+
+    expect(vi.mocked(WEBVIEW_MOCK.postMessage).mock.calls.length === 1).toBe(notified);
   });
 });

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -331,6 +331,7 @@ export class AlternativeService extends Publisher<void> implements AsyncInit, Di
 
   @preDestroy()
   override dispose(): void {
+    super.dispose();
     this.#cancellationToken.cancel();
     this.#disposables.forEach(disposable => disposable.dispose());
   }

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import { inject, injectable, preDestroy } from 'inversify';
+import { inject, injectable, postConstruct, preDestroy } from 'inversify';
 import { TelemetryLoggerSymbol } from '../inject/symbol';
 import {
   CancellationTokenSource,
@@ -38,12 +38,38 @@ import type {
 import alt from '../assets/alt.json' with { type: 'json' };
 import { GrypeService } from './scanners/grype-service';
 import { PromiseQueue } from '../utils/promise-queue';
+import { Publisher } from '/@/utils/publisher';
+import { WebviewService } from '/@/services/webview-service';
+import { Messages } from '@podman-desktop/extension-hummingbird-core-api';
+import type { AsyncInit } from '/@/utils/async-init';
+import { z } from 'zod';
+
+const ContainerEvent = z.object({
+  Type: z.literal('container'),
+  Action: z.literal(['init', 'remove']),
+  Actor: z.object({
+    Attributes: z.object({
+      image: z.string().min(1),
+    }),
+  }),
+});
+
+const ImageEvent = z.object({
+  Type: z.literal('image'),
+  Action: z.literal(['pull', 'delete']),
+  Actor: z.object({
+    Attributes: z.object({
+      name: z.string(),
+    }),
+  }),
+});
 
 @injectable()
-export class AlternativeService implements Disposable {
+export class AlternativeService extends Publisher<void> implements AsyncInit, Disposable {
   #altMap: Map<string, string>;
   #queue: PromiseQueue = new PromiseQueue(2);
   #cancellationToken = new CancellationTokenSource();
+  #disposables: Disposable[] = [];
 
   constructor(
     @inject(TelemetryLoggerSymbol)
@@ -52,7 +78,11 @@ export class AlternativeService implements Disposable {
     protected readonly hummingbirdService: HummingbirdService,
     @inject(GrypeService)
     protected readonly grypeService: GrypeService,
+    @inject(WebviewService)
+    webviewService: WebviewService,
   ) {
+    super(webviewService, Messages.UPDATE_ALTERNATIVES, () => {});
+
     // Create reverse mapping: from alternative repo to hummingbird image name
     this.#altMap = new Map(
       Object.entries(alt).reduce(
@@ -64,6 +94,36 @@ export class AlternativeService implements Disposable {
         },
         [] as [string, string][],
       ),
+    );
+  }
+
+  protected hasAlternative(image: string): boolean {
+    const [repo] = image.split(':');
+    return this.#altMap.has(repo);
+  }
+
+  @postConstruct()
+  async init(): Promise<void> {
+    this.#disposables.push(
+      containerEngineAPI.onEvent(event => {
+        const containerEventParseResult = ContainerEvent.safeParse(event);
+        if (containerEventParseResult.success) {
+          if (this.hasAlternative(containerEventParseResult.data.Actor.Attributes.image)) {
+            return this.notify();
+          } else {
+            return;
+          }
+        }
+
+        const imageEventParseResult = ImageEvent.safeParse(event);
+        if (imageEventParseResult.success) {
+          if (this.hasAlternative(imageEventParseResult.data.Actor.Attributes.name)) {
+            return this.notify();
+          } else {
+            return;
+          }
+        }
+      }),
     );
   }
 
@@ -270,7 +330,8 @@ export class AlternativeService implements Disposable {
   }
 
   @preDestroy()
-  dispose(): void {
+  override dispose(): void {
     this.#cancellationToken.cancel();
+    this.#disposables.forEach(disposable => disposable.dispose());
   }
 }

--- a/packages/frontend/src/routes/alternatives/+page.svelte
+++ b/packages/frontend/src/routes/alternatives/+page.svelte
@@ -4,8 +4,19 @@ import { faWarning } from '@fortawesome/free-solid-svg-icons/faWarning';
 import type { PageProps } from './$types';
 import AlternativeTable from '/@/routes/alternatives/(components)/AlternativeTable.svelte';
 import TableSkeleton from '$lib/skeleton/TableSkeleton.svelte';
+import { onMount } from 'svelte';
+import { rpcBrowser } from '/@/api/client';
+import { invalidate } from '$app/navigation';
+import { Messages } from '@podman-desktop/extension-hummingbird-core-api';
 
 let { data }: PageProps = $props();
+
+onMount(() => {
+  const subscriber = rpcBrowser.subscribe(Messages.UPDATE_ALTERNATIVES, () => {
+    invalidate('alternatives:update').catch(console.error);
+  });
+  return subscriber.unsubscribe;
+});
 </script>
 
 <NavPage title="Hardened Image Alternatives" searchEnabled={false}>

--- a/packages/frontend/src/routes/alternatives/+page.ts
+++ b/packages/frontend/src/routes/alternatives/+page.ts
@@ -23,7 +23,9 @@ interface Data {
   alternatives: Promise<Array<LocalImageAlternative>>;
 }
 
-export const load: PageLoad = async (): Promise<Data> => {
+export const load: PageLoad = async ({ depends }): Promise<Data> => {
+  depends('alternatives:update');
+
   const { promise, resolve } = Promise.withResolvers<void>();
   setTimeout(resolve, 500);
 

--- a/packages/shared/src/messages.ts
+++ b/packages/shared/src/messages.ts
@@ -20,5 +20,6 @@ export enum Messages {
   TEST_PURPOSE = 'test-purpose',
   UPDATE_PROVIDERS = 'update-providers',
   UPDATE_IMAGES = 'update-images',
+  UPDATE_ALTERNATIVES = 'update-alternatives',
   ROUTE_UPDATE = 'route-update',
 }


### PR DESCRIPTION
## Description

Making the Alternative Table reactive to pull / rm / start / delete of image / container with Hummingbird alternatives.

## Screenshots

https://github.com/user-attachments/assets/124dd7dd-531c-46d0-a7ba-75aa04d48e97

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/227

## Testing

1. Go to `Hummingbird > Alternatives`
2. Open a terminal and run any of the following command
- `podman image pull docker.io/alpine/curl`
- `podman run --name=demo-reactivity docker.io/library/postgres:18.3 -d`
3. Assert the table auto update with the new content