### PR TITLE
fix: promise-queue error handling

### DIFF
--- a/packages/backend/src/utils/promise-queue.spec.ts
+++ b/packages/backend/src/utils/promise-queue.spec.ts
@@ -209,3 +209,17 @@ describe('PromiseQueue', () => {
     expect(queue.queuedCount).toBe(0);
   });
 });
+
+test('error on promise creation should be correctly handled', async () => {
+  const queue = new PromiseQueue(2);
+
+  function mThrow(): Promise<void> {
+    throw new Error('test');
+  }
+
+  await expect(async () => {
+    return queue.enqueue(() => mThrow());
+  }).rejects.toThrowError('test');
+
+  expect(queue.runningCount).toBe(0);
+});

--- a/packages/backend/src/utils/promise-queue.ts
+++ b/packages/backend/src/utils/promise-queue.ts
@@ -15,7 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-
 /**
  * A queue that limits the number of concurrent promise executions.
  * When the limit is reached, new promises are queued and executed as previous ones complete.
@@ -46,7 +45,19 @@ export class PromiseQueue {
     return new Promise<T>((resolve, reject) => {
       const task = (): void => {
         this.running++;
-        fn()
+
+        let promise: Promise<T>;
+        // eslint-disable-next-line sonarjs/no-try-promise
+        try {
+          promise = fn();
+        } catch (err: unknown) {
+          reject(err);
+          this.running--;
+          this.processNext();
+          return;
+        }
+
+        promise
           .then(resolve)
           .catch(reject)
           .finally(() => {

--- a/packages/backend/src/utils/promise-queue.ts
+++ b/packages/backend/src/utils/promise-queue.ts
@@ -35,6 +35,11 @@ export class PromiseQueue {
     this.maxConcurrent = maxConcurrent;
   }
 
+  protected onCompleted(): void {
+    this.running--;
+    this.processNext();
+  }
+
   /**
    * Enqueues a function that returns a promise.
    * Returns a promise that resolves/rejects when the enqueued function's promise resolves/rejects.
@@ -52,18 +57,11 @@ export class PromiseQueue {
           promise = fn();
         } catch (err: unknown) {
           reject(err);
-          this.running--;
-          this.processNext();
+          this.onCompleted();
           return;
         }
 
-        promise
-          .then(resolve)
-          .catch(reject)
-          .finally(() => {
-            this.running--;
-            this.processNext();
-          });
+        promise.then(resolve).catch(reject).finally(this.onCompleted.bind(this));
       };
 
       this.queue.push(task);


### PR DESCRIPTION
## Description

When the Grype extension is not installed, an error was thrown but this before the promise creation, making the promise queue failing as it was not handling it properly.

## Related issues 

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/241

## Testing

- [x] unit test have been provided