### PR TITLE
feat(alt-page): improve support when grype is not installed

### DIFF
--- a/packages/backend/src/apis/alternatives-api-impl.spec.ts
+++ b/packages/backend/src/apis/alternatives-api-impl.spec.ts
@@ -24,6 +24,7 @@ import type {
   LocalImageAlternativeReport,
   VulnerabilitiesSummary,
 } from '@podman-desktop/extension-hummingbird-core-api';
+import type { GrypeService } from '/@/services/scanners/grype-service';
 
 const ALTERNATIVE_SERVICE_MOCK: AlternativeService = {
   getAlternatives: vi.fn(),
@@ -45,6 +46,10 @@ const LOCAL_IMAGE_ALT_MOCK: LocalImageAlternative = {
   } as ImageSummary,
 };
 
+const GRYPE_SERVICE_MOCK: GrypeService = {
+  isInstalled: vi.fn(),
+} as unknown as GrypeService;
+
 const LOCAL_IMAGE_ALT_REPORT_MOCK: LocalImageAlternativeReport = {
   localImage: {
     size: 0,
@@ -63,14 +68,14 @@ beforeEach(() => {
 describe('AlternativesApiImpl#getAlternatives', () => {
   test('expect getAlternatives result to be properly propagated from AlternativeService', async () => {
     vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternatives).mockResolvedValue([LOCAL_IMAGE_ALT_MOCK]);
-    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK, GRYPE_SERVICE_MOCK);
     const result = await api.getAlternatives();
     expect(result).toStrictEqual([LOCAL_IMAGE_ALT_MOCK]);
   });
 
   test('expect getAlternatives error to be propagated', async () => {
     vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternatives).mockRejectedValue(new Error('Failed to get alternatives'));
-    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK, GRYPE_SERVICE_MOCK);
 
     await expect(() => {
       return api.getAlternatives();
@@ -81,14 +86,14 @@ describe('AlternativesApiImpl#getAlternatives', () => {
 describe('AlternativesApiImpl#getAlternativeReport', () => {
   test('expect getAlternativeReport result to be properly propagated from AlternativeService', async () => {
     vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternativeReport).mockResolvedValue(LOCAL_IMAGE_ALT_REPORT_MOCK);
-    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK, GRYPE_SERVICE_MOCK);
     const result = await api.getAlternativeReport(LOCAL_IMAGE_ALT_MOCK);
     expect(result).toStrictEqual(LOCAL_IMAGE_ALT_REPORT_MOCK);
   });
 
   test('expect getAlternativeReport error to be propagated', async () => {
     vi.mocked(ALTERNATIVE_SERVICE_MOCK.getAlternativeReport).mockRejectedValue(new Error('Failed to get report'));
-    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK);
+    const api = new AlternativesApiImpl(ALTERNATIVE_SERVICE_MOCK, GRYPE_SERVICE_MOCK);
 
     await expect(() => {
       return api.getAlternativeReport(LOCAL_IMAGE_ALT_MOCK);

--- a/packages/backend/src/apis/alternatives-api-impl.ts
+++ b/packages/backend/src/apis/alternatives-api-impl.ts
@@ -24,14 +24,21 @@ import {
 } from '@podman-desktop/extension-hummingbird-core-api';
 import { inject, injectable } from 'inversify';
 import { AlternativeService } from '../services/alternative-service';
+import { GrypeService } from '/@/services/scanners/grype-service';
 
 @injectable()
 export class AlternativesApiImpl extends AlternativesApi {
   constructor(
     @inject(AlternativeService)
     protected readonly alternativeService: AlternativeService,
+    @inject(GrypeService)
+    protected readonly grypeService: GrypeService,
   ) {
     super();
+  }
+
+  override async isGrypeInstalled(): Promise<boolean> {
+    return this.grypeService.isInstalled();
   }
 
   override async getAlternatives(): Promise<LocalImageAlternative[]> {

--- a/packages/backend/src/apis/routing-api-impl.ts
+++ b/packages/backend/src/apis/routing-api-impl.ts
@@ -18,6 +18,7 @@
 import { RoutingApi } from '@podman-desktop/extension-hummingbird-core-api';
 import { RoutingService } from '/@/services/routing-service';
 import { inject, injectable } from 'inversify';
+import { navigation } from '@podman-desktop/api';
 
 @injectable()
 export class RoutingApiImpl extends RoutingApi {
@@ -30,5 +31,11 @@ export class RoutingApiImpl extends RoutingApi {
 
   override async readRoute(): Promise<string | undefined> {
     return this.routing.read();
+  }
+
+  override navigateToCatalog(searchTerm?: string): Promise<void> {
+    return navigation.navigateToExtensionsCatalog({
+      searchTerm,
+    });
   }
 }

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -227,32 +227,23 @@ export class AlternativeService extends Publisher<void> implements AsyncInit, Di
 
     if (!tag) throw new Error(`Cannot find tag ${alternative.latest_tag} for ${alternative.name}`);
 
-    console.log(
-      `enqueuing getVulnerabilitiesSummary & this.grypeService.api.vulnerability for ${localImage.engineId}:${localImage.id}`,
+    const [altVulnerabilities, localVulnerabilities] = await this.#queue.enqueue(() =>
+      Promise.all([
+        this.hummingbirdService.getVulnerabilitiesSummary(alternative.name, tag.canonical),
+        this.grypeService.api.vulnerability.analyse(
+          {
+            engineId: localImage.engineId,
+            Id: localImage.id,
+          },
+          {
+            task: {
+              title: `Scanning ${localImage.name}:${localImage.tag}`,
+            },
+            token: this.#cancellationToken.token,
+          },
+        ),
+      ]),
     );
-    const [altVulnerabilities, localVulnerabilities] = await this.#queue
-      .enqueue(() =>
-        Promise.all([
-          this.hummingbirdService.getVulnerabilitiesSummary(alternative.name, tag.canonical),
-          this.grypeService.api.vulnerability.analyse(
-            {
-              engineId: localImage.engineId,
-              Id: localImage.id,
-            },
-            {
-              task: {
-                title: `Scanning ${localImage.name}:${localImage.tag}`,
-              },
-              token: this.#cancellationToken.token,
-            },
-          ),
-        ]),
-      )
-      .catch((err: unknown) => {
-        console.error(`Error enqueuing vulnerability scan for ${localImage.engineId}:${localImage.id}`, err);
-        throw err;
-      });
-    console.log(`enqueuing resolved for ${localImage.engineId}:${localImage.id}`);
 
     return {
       localImage: {

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -227,23 +227,32 @@ export class AlternativeService extends Publisher<void> implements AsyncInit, Di
 
     if (!tag) throw new Error(`Cannot find tag ${alternative.latest_tag} for ${alternative.name}`);
 
-    const [altVulnerabilities, localVulnerabilities] = await this.#queue.enqueue(() =>
-      Promise.all([
-        this.hummingbirdService.getVulnerabilitiesSummary(alternative.name, tag.canonical),
-        this.grypeService.api.vulnerability.analyse(
-          {
-            engineId: localImage.engineId,
-            Id: localImage.id,
-          },
-          {
-            task: {
-              title: `Scanning ${localImage.name}:${localImage.tag}`,
-            },
-            token: this.#cancellationToken.token,
-          },
-        ),
-      ]),
+    console.log(
+      `enqueuing getVulnerabilitiesSummary & this.grypeService.api.vulnerability for ${localImage.engineId}:${localImage.id}`,
     );
+    const [altVulnerabilities, localVulnerabilities] = await this.#queue
+      .enqueue(() =>
+        Promise.all([
+          this.hummingbirdService.getVulnerabilitiesSummary(alternative.name, tag.canonical),
+          this.grypeService.api.vulnerability.analyse(
+            {
+              engineId: localImage.engineId,
+              Id: localImage.id,
+            },
+            {
+              task: {
+                title: `Scanning ${localImage.name}:${localImage.tag}`,
+              },
+              token: this.#cancellationToken.token,
+            },
+          ),
+        ]),
+      )
+      .catch((err: unknown) => {
+        console.error(`Error enqueuing vulnerability scan for ${localImage.engineId}:${localImage.id}`, err);
+        throw err;
+      });
+    console.log(`enqueuing resolved for ${localImage.engineId}:${localImage.id}`);
 
     return {
       localImage: {

--- a/packages/backend/src/services/scanners/grype-service.ts
+++ b/packages/backend/src/services/scanners/grype-service.ts
@@ -24,14 +24,8 @@ import { VulnerabilitiesSummary } from '@podman-desktop/extension-hummingbird-co
 
 @injectable()
 export class GrypeService implements AsyncInit, Disposable {
-  #api: GrypeExtensionApi | undefined;
-
   get api(): GrypeExtensionApi {
-    if (this.#api) {
-      return this.#api;
-    }
-    this.#api = this.getGrypeAPI();
-    return this.#api;
+    return this.getGrypeAPI();
   }
 
   public isInstalled(): boolean {
@@ -46,9 +40,7 @@ export class GrypeService implements AsyncInit, Disposable {
     return false;
   }
 
-  dispose(): void {
-    this.#api = undefined;
-  }
+  dispose(): void {}
 
   public toVulnerabilitySummary(document: grype.Document): VulnerabilitiesSummary {
     return document.matches.reduce(
@@ -88,7 +80,7 @@ export class GrypeService implements AsyncInit, Disposable {
 
   protected getGrypeAPI(): GrypeExtensionApi {
     const grype = extensionsAPI.getExtension<GrypeExtensionApi>('podman-desktop.grype');
-    if (grype) {
+    if (grype?.exports) {
       return grype.exports;
     } else {
       throw new Error('cannot find the grype extension');

--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -14,19 +14,20 @@ import ActionColumn from '/@/routes/alternatives/(components)/columns/ActionColu
 
 interface Props {
   alternatives: LocalImageAlternative[];
+  isGrypeInstalled: boolean;
 }
 
-let { alternatives }: Props = $props();
+let { alternatives, isGrypeInstalled }: Props = $props();
 
 let data: Row[] = $derived(
   alternatives.map((alt, index) => ({
     ...alt,
     name: alt.localImage.name,
-    report: alternativesAPI.getAlternativeReport(alt),
+    report: isGrypeInstalled ? alternativesAPI.getAlternativeReport(alt) : Promise.reject(new Error('grype not installed')),
   })),
 );
 
-const columns = [
+let columns = $derived([
   new TableColumn<Row, 'container' | 'image'>('Status', {
     align: 'center',
     width: '70px',
@@ -39,29 +40,33 @@ const columns = [
     renderer: NameColumn,
     overflow: true,
   }),
-  new TableColumn<Row, Promise<LocalImageAlternativeReport> | undefined>('CVEs', {
-    width: '1fr',
-    renderer: CVEReductionCell,
-    align: 'center',
-    renderMapping: (row: Row): Promise<LocalImageAlternativeReport> | undefined =>
-      'report' in row ? row.report : undefined,
-    overflow: true,
-  }),
-  new TableColumn<Row, Promise<LocalImageAlternativeReport> | undefined>('Size Reduction', {
-    width: '1fr',
-    renderer: FilesizeReductionColumn,
-    align: 'center',
-    renderMapping: (row: Row): Promise<LocalImageAlternativeReport> | undefined =>
-      'report' in row ? row.report : undefined,
-    overflow: true,
-  }),
+  ...(isGrypeInstalled
+    ? [
+        new TableColumn<Row, Promise<LocalImageAlternativeReport> | undefined>('CVEs', {
+          width: '1fr',
+          renderer: CVEReductionCell,
+          align: 'center',
+          renderMapping: (row: Row): Promise<LocalImageAlternativeReport> | undefined =>
+            'report' in row ? row.report : undefined,
+          overflow: true,
+        }),
+        new TableColumn<Row, Promise<LocalImageAlternativeReport> | undefined>('Size Reduction', {
+          width: '1fr',
+          renderer: FilesizeReductionColumn,
+          align: 'center',
+          renderMapping: (row: Row): Promise<LocalImageAlternativeReport> | undefined =>
+            'report' in row ? row.report : undefined,
+          overflow: true,
+        }),
+      ]
+    : []),
   new TableColumn<Row>('Actions', {
     align: 'right',
     width: '50px',
     renderer: ActionColumn,
     overflow: true,
   }),
-];
+]);
 
 const row: TableRow<Row> = new TableRow<Row>({
   children: (row): Array<Row> => {

--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -23,7 +23,7 @@ let data: Row[] = $derived(
   alternatives.map((alt, index) => ({
     ...alt,
     name: alt.localImage.name,
-    report: isGrypeInstalled ? alternativesAPI.getAlternativeReport(alt) : Promise.reject(new Error('grype not installed')),
+    report: isGrypeInstalled ? alternativesAPI.getAlternativeReport(alt) : undefined,
   })),
 );
 

--- a/packages/frontend/src/routes/alternatives/(components)/banner/GrypeBanner.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/banner/GrypeBanner.spec.ts
@@ -15,27 +15,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { PageLoad } from './$types';
-import type { LocalImageAlternative } from '@podman-desktop/extension-hummingbird-core-api';
-import { alternativesAPI } from '/@/api/client';
 
-interface Data {
-  alternatives: Promise<Array<LocalImageAlternative>>;
-  isGrypeInstalled: boolean;
-}
+import '@testing-library/jest-dom/vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import { expect, test, vi } from 'vitest';
+import GrypeBanner from './GrypeBanner.svelte';
+import { routingAPI } from '/@/api/client';
 
-export const load: PageLoad = async ({ depends }): Promise<Data> => {
-  depends('alternatives:update');
+vi.mock(import('/@/api/client'), () => ({
+  routingAPI: {
+    navigateToCatalog: vi.fn(),
+    readRoute: vi.fn(),
+  },
+}));
 
-  const isGrypeInstalled = await alternativesAPI.isGrypeInstalled();
+test('Expect that GrypeBanner button calls navigateToCatalog', async () => {
+  render(GrypeBanner);
 
-  const { promise, resolve } = Promise.withResolvers<void>();
-  setTimeout(resolve, 500);
+  const button = screen.getByRole('button', { name: 'Check catalog' });
+  expect(button).toBeInTheDocument();
 
-  const alternatives = Promise.all([alternativesAPI.getAlternatives(), promise]).then(([alternatives]) => alternatives);
+  await fireEvent.click(button);
 
-  return {
-    alternatives,
-    isGrypeInstalled,
-  };
-};
+  expect(routingAPI.navigateToCatalog).toHaveBeenCalledWith('grype');
+});

--- a/packages/frontend/src/routes/alternatives/(components)/banner/GrypeBanner.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/banner/GrypeBanner.svelte
@@ -1,0 +1,42 @@
+<style>
+.page-description {
+  margin-bottom: 16px;
+  padding: 12px 16px;
+  background: rgba(168, 85, 247, 0.08);
+  border-left: 3px solid var(--pd-link);
+  border-radius: 0 4px 4px 0;
+}
+.page-description p {
+  color: var(--pd-content-text);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
+}
+.page-description strong {
+  color: var(--pd-badge-green);
+}
+</style>
+
+<script lang="ts">
+import { Button } from '@podman-desktop/ui-svelte';
+import { routingAPI } from '/@/api/client';
+import type { ClassValue } from 'svelte/elements';
+
+interface Props {
+  class?: ClassValue;
+}
+
+let { class: className }: Props = $props();
+
+function navigateToCatalog(): Promise<void> {
+  return routingAPI.navigateToCatalog('grype');
+}
+</script>
+
+<div class={['page-description', className]}>
+  <p>
+    To compare vulnerabilities between your local images and the Hummingbird alternatives you can install the Grype
+    extension
+  </p>
+  <Button title="Check catalog" onclick={navigateToCatalog}>Check catalog</Button>
+</div>

--- a/packages/frontend/src/routes/alternatives/(components)/row.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/row.ts
@@ -30,7 +30,7 @@ export type ContainerRow = BaseRow & LocalContainer;
 
 export type AlternativeRow = BaseRow &
   LocalImageAlternative & {
-    report: Promise<LocalImageAlternativeReport>;
+    report: Promise<LocalImageAlternativeReport> | undefined;
   };
 
 export type Row = ContainerRow | AlternativeRow;

--- a/packages/frontend/src/routes/alternatives/+page.svelte
+++ b/packages/frontend/src/routes/alternatives/+page.svelte
@@ -8,6 +8,7 @@ import { onMount } from 'svelte';
 import { rpcBrowser } from '/@/api/client';
 import { invalidate } from '$app/navigation';
 import { Messages } from '@podman-desktop/extension-hummingbird-core-api';
+import GrypeBanner from '/@/routes/alternatives/(components)/banner/GrypeBanner.svelte';
 
 let { data }: PageProps = $props();
 
@@ -17,31 +18,31 @@ onMount(() => {
   });
   return subscriber.unsubscribe;
 });
+
+let columns = $derived([
+  {
+    name: 'Original Image',
+    width: '1.5fr',
+  },
+  ...(data.isGrypeInstalled
+    ? [
+        {
+          name: 'CVEs',
+          width: '1fr',
+        },
+        {
+          name: 'Size Reduction',
+          width: '1fr',
+        },
+      ]
+    : []),
+]);
 </script>
 
 <NavPage title="Hardened Image Alternatives" searchEnabled={false}>
   {#snippet content()}
     {#await data.alternatives}
-      <TableSkeleton
-        count={20}
-        columns={[
-          {
-            name: 'Original Image',
-            width: '1.5fr',
-          },
-          {
-            name: 'Alternative',
-            width: '1.5fr',
-          },
-          {
-            name: 'CVEs',
-            width: '1fr',
-          },
-          {
-            name: 'Size Reduction',
-            width: '1fr',
-          },
-        ]} />
+      <TableSkeleton count={20} columns={columns} />
     {:then alternatives}
       {#if alternatives.length === 0}
         <EmptyScreen
@@ -51,7 +52,15 @@ onMount(() => {
           message="No local images with Hummingbird alternatives were found. Pull some common images like nginx, postgres, or python to see alternatives.">
         </EmptyScreen>
       {:else}
-        <AlternativeTable alternatives={alternatives} />
+        <div class="flex flex-col w-full h-full">
+          {#if !data.isGrypeInstalled}
+            <GrypeBanner class="mx-5" />
+          {/if}
+
+          <div class="w-full flex">
+            <AlternativeTable alternatives={alternatives} isGrypeInstalled={data.isGrypeInstalled} />
+          </div>
+        </div>
       {/if}
     {:catch error}
       <EmptyScreen

--- a/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
@@ -61,6 +61,7 @@ describe('error', () => {
     const { getByLabelText } = render(Page, {
       data: {
         alternatives: Promise.reject<Array<LocalImageAlternative>>(ERROR_MOCK),
+        isGrypeInstalled: false,
       },
       params: {},
     });
@@ -78,6 +79,7 @@ describe('loading', () => {
     const { getByRole } = render(Page, {
       data: {
         alternatives: new Promise<Array<LocalImageAlternative>>(vi.fn()),
+        isGrypeInstalled: false,
       },
       params: {},
     });
@@ -92,6 +94,7 @@ describe('data', () => {
     const { getByLabelText } = render(Page, {
       data: {
         alternatives: Promise.resolve(ALTERNATIVES),
+        isGrypeInstalled: false,
       },
       params: {},
     });
@@ -105,6 +108,7 @@ describe('data', () => {
     const { getByLabelText } = render(Page, {
       data: {
         alternatives: Promise.resolve([]),
+        isGrypeInstalled: false,
       },
       params: {},
     });

--- a/packages/shared/src/apis/alternatives-api.ts
+++ b/packages/shared/src/apis/alternatives-api.ts
@@ -23,6 +23,8 @@ import type { OptimisationReport } from '../models/optimization-report';
 export abstract class AlternativesApi {
   static readonly CHANNEL: string = 'alternatives-api';
 
+  abstract isGrypeInstalled(): Promise<boolean>;
+
   /**
    * Get all local images that have Hummingbird alternatives
    */

--- a/packages/shared/src/apis/routing-api.ts
+++ b/packages/shared/src/apis/routing-api.ts
@@ -23,4 +23,6 @@ export abstract class RoutingApi {
    * route it should use. This method has a side effect of removing the pending route after calling.
    */
   abstract readRoute(): Promise<string | undefined>;
+
+  abstract navigateToCatalog(searchTerm?: string): Promise<void>;
 }


### PR DESCRIPTION
## Description

When the grype extension is not installed, in the alternative page we can omit the two columns `CVEs reduction` and `Size reduction`.

> :information_source: technically the size reduction could be kept, but with the current implementation this is tied to the grype analysis so simply omitting for now. 

## Screenshots

<img width="1246" height="227" alt="image" src="https://github.com/user-attachments/assets/45535736-99cf-4497-8483-1605f3177ebe" />

https://github.com/user-attachments/assets/59467e5b-c73f-4c3f-a96a-dad1884c8746

## Related issues

Require rebase after 
- https://github.com/redhat-developer/podman-desktop-hummingbird-ext/pull/242

## Testing

- [x] unit tests mostly added