### PR TITLE
feat(frontend): disable the open action 

### DIFF
--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
@@ -101,6 +101,33 @@ test('should navigate to image report when info button is clicked', async () => 
   );
 });
 
+test('info button should have appropriate tooltip', async () => {
+  const alternativeRow = {
+    name: 'nginx:latest',
+    localImage: {
+      id: 'sha256:abc123',
+      engineId: 'podman',
+      name: 'nginx',
+      tag: 'latest',
+      size: 1024000,
+      architecture: 'amd64',
+      containers: [],
+    },
+    alternative: {
+      name: 'nginx',
+      latest_tag: '1.21',
+    },
+    report: undefined,
+  } as unknown as AlternativeRow;
+
+  const { getByRole } = render(ActionColumn, { object: alternativeRow });
+
+  const button = getByRole('button', {
+    name: 'You need to install Grype extension to access full report.',
+  });
+  expect(button).toBeInTheDocument();
+});
+
 test('should navigate to clone container when clone button is clicked', async () => {
   const containerRow = {
     name: 'my-container',

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
@@ -39,8 +39,9 @@ function onCloneContainer(engineId: string, containerId: string): Promise<void> 
 {#if 'report' in object}
   <ListItemButtonIcon
     icon={faInfoCircle}
+    enabled={object.report !== undefined}
     onClick={onOpenImageReport.bind(undefined, object.localImage.engineId, object.localImage.id)}
-    title="Open Image Report Details" />
+    title={(object.report) ? 'Open Image Report Details' : 'You need to install Grype extension to access full report.'} />
 {:else}
   <ListItemButtonIcon
     icon={faClone}

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
@@ -41,7 +41,9 @@ function onCloneContainer(engineId: string, containerId: string): Promise<void> 
     icon={faInfoCircle}
     enabled={object.report !== undefined}
     onClick={onOpenImageReport.bind(undefined, object.localImage.engineId, object.localImage.id)}
-    title={(object.report) ? 'Open Image Report Details' : 'You need to install Grype extension to access full report.'} />
+    title={object.report
+      ? 'Open Image Report Details'
+      : 'You need to install Grype extension to access full report.'} />
 {:else}
   <ListItemButtonIcon
     icon={faClone}


### PR DESCRIPTION
## Description

As the report page is mostly displaying information from the Grype extension, we should disable the navigate button when grype is not installed.
 
## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/225

## Testing

- [x] unit tests have been added
