### PR TITLE
feat(clone-form): add redirect button

### DIFF
--- a/packages/backend/src/apis/routing-api-impl.ts
+++ b/packages/backend/src/apis/routing-api-impl.ts
@@ -38,4 +38,8 @@ export class RoutingApiImpl extends RoutingApi {
       searchTerm,
     });
   }
+
+  override navigateToContainerDetails(_: string, containerId: string): Promise<void> {
+    return navigation.navigateToContainer(containerId);
+  }
 }

--- a/packages/frontend/src/routes/alternatives/(components)/banner/GrypeBanner.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/banner/GrypeBanner.spec.ts
@@ -24,6 +24,7 @@ import { routingAPI } from '/@/api/client';
 
 vi.mock(import('/@/api/client'), () => ({
   routingAPI: {
+    navigateToContainerDetails: vi.fn(),
     navigateToCatalog: vi.fn(),
     readRoute: vi.fn(),
   },

--- a/packages/frontend/src/routes/containers/[engineId]/[id]/clone/(components)/CloneForm.spec.ts
+++ b/packages/frontend/src/routes/containers/[engineId]/[id]/clone/(components)/CloneForm.spec.ts
@@ -1,0 +1,104 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import { expect, test, vi, beforeEach } from 'vitest';
+import CloneForm from './CloneForm.svelte';
+import { containerAPI } from '/@/api/client';
+import type { LocalContainer, ImageSummary, LocalImage } from '@podman-desktop/extension-hummingbird-core-api';
+
+vi.mock(import('/@/api/client'), () => ({
+  containerAPI: {
+    clone: vi.fn(),
+    getContainer: vi.fn(),
+  },
+  routingAPI: {
+    navigateToContainerDetails: vi.fn(),
+    navigateToCatalog: vi.fn(),
+    readRoute: vi.fn(),
+  },
+}));
+
+const CONTAINER = {
+  id: 'container-id',
+  engineId: 'podman',
+  name: 'my-container',
+} as unknown as LocalContainer;
+
+const ALTERNATIVE = {
+  name: 'nginx-hardened',
+  latest_tag: '1.2.3',
+} as unknown as ImageSummary;
+
+const LOCAL_IMAGE = {
+  name: 'nginx',
+  tag: 'latest',
+} as unknown as Omit<LocalImage, 'containers'>;
+
+const CLOSE_FN = vi.fn();
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+test('Expect that clicking Clone calls containerAPI.clone', async () => {
+  vi.mocked(containerAPI.clone).mockResolvedValue({
+    Id: 'new-container-id',
+    engineId: 'podman',
+  });
+
+  const { getByRole, getByText } = render(CloneForm, {
+    container: CONTAINER,
+    alternative: ALTERNATIVE,
+    localImage: LOCAL_IMAGE,
+    close: CLOSE_FN,
+  });
+
+  const cloneButton = getByRole('button', { name: 'Clone' });
+  await fireEvent.click(cloneButton);
+
+  expect(containerAPI.clone).toHaveBeenCalledWith(
+    'podman',
+    'container-id',
+    'quay.io/hummingbird/nginx-hardened:1.2.3',
+    {
+      stopBeforeClone: true,
+      name: 'my-container-clone',
+    },
+  );
+
+  expect(getByText('Container new-cont created')).toBeInTheDocument();
+  expect(getByRole('button', { name: 'Open container details' })).toBeInTheDocument();
+});
+
+test('Expect that cloning error is displayed', async () => {
+  vi.mocked(containerAPI.clone).mockRejectedValue(new Error('Clone failed!'));
+
+  const { getByRole, getByText } = render(CloneForm, {
+    container: CONTAINER,
+    alternative: ALTERNATIVE,
+    localImage: LOCAL_IMAGE,
+    close: CLOSE_FN,
+  });
+
+  const cloneButton = getByRole('button', { name: 'Clone' });
+  await fireEvent.click(cloneButton);
+
+  expect(getByText('Error: Clone failed!')).toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/containers/[engineId]/[id]/clone/(components)/CloneForm.svelte
+++ b/packages/frontend/src/routes/containers/[engineId]/[id]/clone/(components)/CloneForm.svelte
@@ -7,7 +7,8 @@ import type {
 } from '@podman-desktop/extension-hummingbird-core-api';
 import { Input, Checkbox, Button, ErrorMessage } from '@podman-desktop/ui-svelte';
 import WarningBanner from '/@/routes/containers/[engineId]/[id]/clone/(components)/WarningBanner.svelte';
-import { containerAPI } from '/@/api/client';
+import { containerAPI, routingAPI } from '/@/api/client';
+import { faInfoCircle } from '@fortawesome/free-solid-svg-icons/faInfoCircle';
 
 interface Props {
   container: LocalContainer;
@@ -44,6 +45,11 @@ async function clone(): Promise<void> {
     loading = false;
   }
 }
+
+async function navigateToContainer(): Promise<void> {
+  if (!result) return;
+  return routingAPI.navigateToContainerDetails(result.engineId, result.Id);
+}
 </script>
 
 <div class="m-5">
@@ -51,7 +57,7 @@ async function clone(): Promise<void> {
 
   <!-- form -->
   <div class="bg-[var(--pd-content-card-bg)] space-y-6 px-8 sm:pb-6 xl:pb-8 rounded-lg h-fit">
-    <div class="w-full">
+    <div class="w-full flex flex-col">
       <label for="new-base-image" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
         >New base image</label>
       <div class="flex items-center gap-2">
@@ -66,21 +72,26 @@ async function clone(): Promise<void> {
 
       <label for="new-container-name" class="pt-4 block mb-2 font-bold text-[var(--pd-content-card-header-text)]"
         >New container name</label>
-      <Input name="new-container-name" bind:value={name} readonly={loading} />
+      <Input name="new-container-name" bind:value={name} readonly={loading || !!result} />
 
       <label class="flex items-center gap-2 cursor-pointer mt-4">
-        <Checkbox bind:checked={stopExisting} disabled={loading} />
+        <Checkbox bind:checked={stopExisting} disabled={loading || !!result} />
         <span class="text-[var(--pd-content-text)]"> Stop existing container before proceeding (recommended) </span>
       </label>
 
+      {#if result}
+        <span class="mt-2">Container {result.Id.substring(0, 8)} created</span>
+      {/if}
+
       <div class="w-full flex flex-row gap-x-2 justify-end pt-4">
         <Button type="secondary" onclick={close} title="Close">Close</Button>
-        <Button onclick={clone} inProgress={loading} disabled={loading || !!result} title="Clone">Clone</Button>
-      </div>
 
-      {#if result}
-        <span>Container {result.Id.substring(0, 8)} created</span>
-      {/if}
+        {#if result}
+          <Button onclick={navigateToContainer} title="Clone" icon={faInfoCircle}>Open container details</Button>
+        {:else}
+          <Button onclick={clone} inProgress={loading} disabled={loading || !!result} title="Clone">Clone</Button>
+        {/if}
+      </div>
 
       {#if error}
         <ErrorMessage error={error} />

--- a/packages/shared/src/apis/routing-api.ts
+++ b/packages/shared/src/apis/routing-api.ts
@@ -25,4 +25,6 @@ export abstract class RoutingApi {
   abstract readRoute(): Promise<string | undefined>;
 
   abstract navigateToCatalog(searchTerm?: string): Promise<void>;
+
+  abstract navigateToContainerDetails(engineId: string, containerId: string): Promise<void>;
 }


### PR DESCRIPTION
## Description

When cloning a container (and replacing base image with Hummingbird alternative) you can now directly open the details of the container you just created.

## Screenshots

<img width="1228" height="601" alt="image" src="https://github.com/user-attachments/assets/43478621-bbf9-42d7-a4d7-547afe932695" />


https://github.com/user-attachments/assets/693e9f06-a6b3-4c0d-aa53-b1bcfdabed47

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/249

## Testing

- [x] unit tests have been added

**Manually**

1. Run a container with an image which has an Hummingbird alternative (E.g. `podman run --name potatoes-db -d docker.io/library/postgres:18.3`).
2. Go to `Hummingbird > Alternatives`
3. Assert your container is visible 
4. Click on the `Clone Container` action
5. On the form, click on Clone
6. Once finished, assert the primary button is now `Open Container Details`
7. Click on it
8. Assert it redirect you to the new container 




