### PR TITLE
feat(clone-form): add task

### DIFF
--- a/__mocks__/@podman-desktop/api.ts
+++ b/__mocks__/@podman-desktop/api.ts
@@ -98,6 +98,8 @@ const plugin = {
     listImages: vi.fn(),
     listContainers: vi.fn(),
     onEvent: vi.fn(),
+    pullImage: vi.fn(),
+    replicatePodmanContainer: vi.fn(),
   } as unknown as typeof podmanDesktopApi.containerEngine,
   configuration: {} as unknown as typeof podmanDesktopApi.configuration,
   authentication: {} as unknown as typeof podmanDesktopApi.authentication,

--- a/packages/backend/src/apis/container-api-impl.ts
+++ b/packages/backend/src/apis/container-api-impl.ts
@@ -61,6 +61,11 @@ export class ContainerApiImpl extends ContainerApi {
     }
 
     // Clone the container with the alternative image
-    return await this.podmanService.clone(engineId, containerId, alternativeImage, options);
+    return await this.podmanService.clone(engineId, containerId, alternativeImage, {
+      ...options,
+      task: {
+        title: `Cloning container ${container.Name} (${container.Id.substring(0, 8)})`,
+      },
+    });
   }
 }

--- a/packages/backend/src/services/hummingbird-service.spec.ts
+++ b/packages/backend/src/services/hummingbird-service.spec.ts
@@ -58,6 +58,7 @@ beforeEach(() => {
     getSbom: vi.fn(),
     getTags: vi.fn(),
     getVulnerabilities: vi.fn(),
+    getCatalogVulnerabilities: vi.fn(),
   };
 
   vi.mocked(Api.prototype.v1.getImages).mockResolvedValue({

--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -15,13 +15,25 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
-import type { ProviderContainerConnection, Extension, ContainerEngineInfo, TelemetryLogger } from '@podman-desktop/api';
-import { extensions as extensionsAPI, containerEngine as containerEngineAPI } from '@podman-desktop/api';
+import type {
+  ProviderContainerConnection,
+  Extension,
+  ContainerEngineInfo,
+  TelemetryLogger,
+  CancellationToken,
+} from '@podman-desktop/api';
+import {
+  extensions as extensionsAPI,
+  containerEngine as containerEngineAPI,
+  window as windowAPI,
+  ProgressLocation,
+} from '@podman-desktop/api';
 import type { PodmanExtensionApi } from '@podman-desktop/podman-extension-api';
 
 import { beforeEach, vi, test, expect, describe } from 'vitest';
 import { PodmanService } from '/@/services/podman-service';
 import type { ProviderService } from '/@/services/provider-service';
+import { TelemetryEvents } from '/@/utils/telemetry-events';
 
 const PROVIDER_SERVICE_MOCK: ProviderService = {
   getContainerConnections: vi.fn(),
@@ -54,12 +66,20 @@ const TELEMETRY_LOGGER_MOCK: TelemetryLogger = {
   dispose: vi.fn(),
 };
 
+const CANCELLATION_TOKEN_MOCK: CancellationToken = {
+  onCancellationRequested: vi.fn(),
+  isCancellationRequested: false,
+} as CancellationToken;
+
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(extensionsAPI.getExtension).mockReturnValue(PODMAN_EXTENSION_MOCK);
   vi.mocked(PROVIDER_SERVICE_MOCK.getContainerConnections).mockReturnValue([STARTED_PROVIDER_CONNECTION_MOCK]);
   vi.mocked(containerEngineAPI.listInfos).mockResolvedValue([ENGINE_INFO_MOCK]);
+  vi.mocked(windowAPI.withProgress).mockImplementation(async (_, task) => {
+    return task({ report: vi.fn() }, CANCELLATION_TOKEN_MOCK);
+  });
 });
 
 function getPodmanService(): PodmanService {
@@ -118,6 +138,89 @@ describe('getRunningProviderContainerConnectionByEngineId', () => {
 
     await expect(service.getRunningProviderContainerConnectionByEngineId('test-engine-id')).rejects.toThrowError(
       'connection not found for engineId test-engine-id',
+    );
+  });
+});
+
+describe('clone', () => {
+  test('should pull image and replicate container', async () => {
+    vi.mocked(containerEngineAPI.replicatePodmanContainer).mockResolvedValue({
+      Id: 'new-container-id',
+      Warnings: [],
+    });
+
+    const service = getPodmanService();
+    const result = await service.clone('test-engine-id', 'old-container-id', 'alt-image', {
+      name: 'new-name',
+      task: {
+        title: 'Cloning container',
+      },
+    });
+
+    expect(windowAPI.withProgress).toHaveBeenCalledExactlyOnceWith(
+      {
+        location: ProgressLocation.TASK_WIDGET,
+        title: 'Cloning container',
+      },
+      expect.any(Function),
+    );
+
+    expect(result).toStrictEqual({
+      engineId: 'test-engine-id',
+      Id: 'new-container-id',
+    });
+
+    expect(containerEngineAPI.pullImage).toHaveBeenCalledWith(
+      STARTED_PROVIDER_CONNECTION_MOCK.connection,
+      'alt-image',
+      expect.any(Function),
+      undefined,
+      CANCELLATION_TOKEN_MOCK,
+    );
+
+    expect(containerEngineAPI.replicatePodmanContainer).toHaveBeenCalledWith(
+      {
+        engineId: 'test-engine-id',
+        id: 'old-container-id',
+      },
+      {
+        engineId: 'test-engine-id',
+      },
+      {
+        image: 'alt-image',
+        name: 'new-name',
+      },
+    );
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      TelemetryEvents.CLONE_CONTAINER,
+      expect.objectContaining({
+        alternative: 'alt-image',
+        warnings: 0,
+      }),
+    );
+  });
+
+  test('should log error telemetry if clone fails', async () => {
+    const error = new Error('clone failed');
+    vi.mocked(containerEngineAPI.replicatePodmanContainer).mockRejectedValue(error);
+
+    const service = getPodmanService();
+    await expect(
+      service.clone('test-engine-id', 'old-container-id', 'alt-image', {
+        name: 'new-name',
+        task: {
+          title: 'Cloning container',
+        },
+      }),
+    ).rejects.toThrowError(error);
+
+    expect(TELEMETRY_LOGGER_MOCK.logUsage).toHaveBeenCalledWith(
+      TelemetryEvents.CLONE_CONTAINER,
+      expect.objectContaining({
+        alternative: 'alt-image',
+        error: error,
+      }),
     );
   });
 });

--- a/packages/backend/src/services/podman-service.ts
+++ b/packages/backend/src/services/podman-service.ts
@@ -1,5 +1,12 @@
-import type { ProviderContainerConnection, Disposable, TelemetryLogger } from '@podman-desktop/api';
-import { extensions as extensionsAPI, containerEngine as containerEngineAPI } from '@podman-desktop/api';
+import {
+  containerEngine as containerEngineAPI,
+  Disposable,
+  extensions as extensionsAPI,
+  ProgressLocation,
+  ProviderContainerConnection,
+  TelemetryLogger,
+  window as windowAPI,
+} from '@podman-desktop/api';
 import type { PodmanExtensionApi } from '@podman-desktop/podman-extension-api';
 import { PODMAN_EXTENSION_ID } from '/@/utils/constants';
 import { ProviderService } from '/@/services/provider-service';
@@ -66,6 +73,9 @@ export class PodmanService implements Disposable {
     alternative: string,
     options: {
       name: string;
+      task: {
+        title: string;
+      };
     },
   ): Promise<{
     engineId: string;
@@ -79,36 +89,44 @@ export class PodmanService implements Disposable {
     const start = performance.now();
 
     try {
-      const connection = await this.getRunningProviderContainerConnectionByEngineId(engineId);
-
-      // Pull the image
-      await containerEngineAPI.pullImage(connection.connection, alternative, console.debug);
-
-      // Replicate the podman container
-      const result = await containerEngineAPI.replicatePodmanContainer(
+      return await windowAPI.withProgress(
         {
-          engineId,
-          id: containerId,
+          location: ProgressLocation.TASK_WIDGET,
+          title: options.task.title,
         },
-        {
-          engineId,
-        },
-        {
-          image: alternative,
-          name: options.name,
+        async (_, token) => {
+          const connection = await this.getRunningProviderContainerConnectionByEngineId(engineId);
+
+          // Pull the image
+          await containerEngineAPI.pullImage(connection.connection, alternative, console.debug, undefined, token);
+
+          // Replicate the podman container
+          const result = await containerEngineAPI.replicatePodmanContainer(
+            {
+              engineId,
+              id: containerId,
+            },
+            {
+              engineId,
+            },
+            {
+              image: alternative,
+              name: options.name,
+            },
+          );
+
+          if (result.Warnings) {
+            console.warn('warnings', result.Warnings.join('\n'));
+          }
+
+          telemetry['warnings'] = result.Warnings.length;
+
+          return {
+            engineId,
+            Id: result.Id,
+          };
         },
       );
-
-      if (result.Warnings) {
-        console.warn('warnings', result.Warnings.join('\n'));
-      }
-
-      telemetry['warnings'] = result.Warnings.length;
-
-      return {
-        engineId,
-        Id: result.Id,
-      };
     } catch (err: unknown) {
       telemetry['error'] = err;
       throw err;


### PR DESCRIPTION
## Description

Cloning a container will create a task in the Task Manager.

## Screenshots

https://github.com/user-attachments/assets/9dbcb4ae-1510-4ed3-b47d-b3a4cf8f5dd2

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/260

## Testing

You can reproduce the video above

- [x] unit tests have been added