### PR TITLE
feat(frontend): handle bigger and insecure Hummingbird alt

### DIFF
--- a/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.spec.ts
@@ -56,6 +56,40 @@ test('should display local and alternative sizes', () => {
 
   expect(screen.getByText('100 MB')).toBeInTheDocument();
   expect(screen.getByText('50 MB')).toBeInTheDocument();
+  expect(screen.getByText('50 MB')).toHaveClass('text-green-400');
+});
+
+test('should not have green text when alternative size is larger', () => {
+  const report: LocalImageAlternativeReport = {
+    localImage: {
+      size: 50_000_000,
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 0,
+      },
+    },
+    alternative: {
+      size: 100_000_000,
+      vulnerabilities: {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        negligible: 0,
+        unknown: 0,
+        total: 0,
+      },
+    },
+  };
+
+  render(FilesizeLocalImageAlternativeReport, { object: report });
+
+  expect(screen.getByText('100 MB')).not.toHaveClass('text-green-400');
 });
 
 test('should display size reduction percentage and saved amount', () => {

--- a/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.svelte
@@ -24,6 +24,14 @@ let saved = $derived.by(() => {
   if (!reduction || reduction <= 0) return undefined;
   return filesize(reduction);
 });
+
+let result: 'smaller' | 'larger' | 'equal' | undefined = $derived.by(() => {
+  if (!valid) return undefined;
+  if (reduction === undefined) return undefined;
+  if (reduction > 0) return 'smaller';
+  if (reduction < 0) return 'larger';
+  return 'equal';
+});
 </script>
 
 {#if valid}
@@ -31,16 +39,17 @@ let saved = $derived.by(() => {
     <div class="flex items-center gap-2">
       <span class="text-base font-medium">{filesize(object.localImage.size)}</span>
       <span class="text-[var(--pd-content-text)] opacity-30">→</span>
-      <span class="text-base font-medium text-green-400">{filesize(object.alternative.size)}</span>
+      <span class:text-green-400={result === 'smaller'} class="text-base font-medium"
+        >{filesize(object.alternative.size)}</span>
     </div>
-    {#if reduction !== undefined && reduction > 0}
+    {#if result === 'smaller'}
       <div class="flex items-center gap-1">
         <span class="text-sm text-green-400">-{reductionPercent}% smaller</span>
         <span class="text-xs text-[var(--pd-content-text)] opacity-50">({saved} saved)</span>
       </div>
-    {:else if reduction !== undefined && reduction < 0}
+    {:else if result === 'larger'}
       <span class="text-xs text-[var(--pd-content-text)] opacity-50">Larger</span>
-    {:else}
+    {:else if result === 'equal'}
       <span class="text-xs text-[var(--pd-content-text)] opacity-50">Same size</span>
     {/if}
   </div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import type { OptimisationReport } from '@podman-desktop/extension-hummingbird-core-api';
-import { SvelteSet } from 'svelte/reactivity';
 import RawReport from '/@/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.svelte';
 import { EmptyScreen } from '@podman-desktop/ui-svelte';
 import { faShieldHalved } from '@fortawesome/free-solid-svg-icons/faShieldHalved';
@@ -10,11 +9,6 @@ interface Props {
 }
 
 let { object }: Props = $props();
-
-const imagePkgs = $derived(new SvelteSet(object.image.sbom?.packages ?? []));
-const altPkgs = $derived(new SvelteSet(object.alternative?.sbom?.packages?.map(p => p.name) ?? []));
-
-const allPkgs = $derived(Array.from(new Set([...imagePkgs, ...altPkgs])).sort((a, b) => a.localeCompare(b)));
 </script>
 
 {#if object.alternative}

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.spec.ts
@@ -42,3 +42,14 @@ test('Expect that ReportBanner does not display CVE info when not provided', asy
   expect(screen.queryByText('CVEs')).not.toBeInTheDocument();
   expect(screen.getByText('-40%')).toBeInTheDocument();
 });
+
+test('Expect that Optimization metrics region to be hidden if both cve and size are not positive', async () => {
+  render(ReportBanner, {
+    cveReductionCount: -10,
+    cveReductionPercent: -50,
+    sizeReductionPercent: -10,
+  });
+
+  const region = screen.getByRole('region', { name: 'Optimization metrics' });
+  expect(region).toHaveClass('hidden');
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.svelte
@@ -19,11 +19,12 @@ let { cveReductionCount, cveReductionPercent, sizeReductionPercent }: Props = $p
       </div>
       <div class="flex flex-col">
         <span class="text-lg font-bold text-purple-300">Hardened Alternative Found!</span>
-        <span class="text-sm text-[var(--pd-content-text)] opacity-70"
+        <span class:hidden={!!cveReductionPercent && cveReductionPercent <= 0} class="text-sm text-[var(--pd-content-text)] opacity-70"
           >A Hummingbird image is available with significant security improvements</span>
       </div>
     </div>
-    <div class="flex items-center gap-8 bg-[var(--pd-content-card-bg)]/50 rounded-lg px-6 py-3">
+
+    <div class:hidden={(!!cveReductionPercent && cveReductionPercent <= 0) && (!!sizeReductionPercent && sizeReductionPercent <= 0)} class="flex items-center gap-8 bg-[var(--pd-content-card-bg)]/50 rounded-lg px-6 py-3">
       {#if cveReductionCount !== undefined && cveReductionPercent !== undefined}
         <!-- CVEs -->
         <div class="text-center">
@@ -38,7 +39,7 @@ let { cveReductionCount, cveReductionPercent, sizeReductionPercent }: Props = $p
         </div>
       {/if}
 
-      {#if sizeReductionPercent !== undefined}
+      {#if sizeReductionPercent !== undefined && sizeReductionPercent > 0}
         <!-- Size Reduction -->
         <div class="text-center">
           <div class="text-3xl font-bold text-purple-300">-{sizeReductionPercent.toFixed(0)}%</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportBanner.svelte
@@ -19,12 +19,21 @@ let { cveReductionCount, cveReductionPercent, sizeReductionPercent }: Props = $p
       </div>
       <div class="flex flex-col">
         <span class="text-lg font-bold text-purple-300">Hardened Alternative Found!</span>
-        <span class:hidden={!!cveReductionPercent && cveReductionPercent <= 0} class="text-sm text-[var(--pd-content-text)] opacity-70"
+        <span
+          class:hidden={!!cveReductionPercent && cveReductionPercent <= 0}
+          class="text-sm text-[var(--pd-content-text)] opacity-70"
           >A Hummingbird image is available with significant security improvements</span>
       </div>
     </div>
 
-    <div class:hidden={(!!cveReductionPercent && cveReductionPercent <= 0) && (!!sizeReductionPercent && sizeReductionPercent <= 0)} class="flex items-center gap-8 bg-[var(--pd-content-card-bg)]/50 rounded-lg px-6 py-3">
+    <div
+      role="region"
+      aria-label="Optimization metrics"
+      class:hidden={!!cveReductionPercent &&
+        cveReductionPercent <= 0 &&
+        !!sizeReductionPercent &&
+        sizeReductionPercent <= 0}
+      class="flex items-center gap-8 bg-[var(--pd-content-card-bg)]/50 rounded-lg px-6 py-3">
       {#if cveReductionCount !== undefined && cveReductionPercent !== undefined}
         <!-- CVEs -->
         <div class="text-center">

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.spec.ts
@@ -36,3 +36,17 @@ test('Expect that ReportComparison displays comparison info', async () => {
   expect(screen.getByText('Only 5 CVE vs 20')).toBeInTheDocument();
   expect(screen.getByText('Try the Alternate Base Image')).toBeInTheDocument();
 });
+
+test('Expect that ReportComparison hides benefits and bars when reduction is not positive', async () => {
+  render(ReportComparison, {
+    cveReductionPercent: 0,
+    sizeReductionPercent: 0,
+    altCveCount: 20,
+    imageCveCount: 20,
+    altSize: 100 * 1024 * 1024,
+    imageSize: 100 * 1024 * 1024,
+  });
+
+  expect(screen.queryByText('Image Size')).not.toBeInTheDocument();
+  expect(screen.queryByText('CVE Count')).not.toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportComparison.svelte
@@ -13,17 +13,25 @@ interface Props {
 
 let { cveReductionPercent, sizeReductionPercent, altCveCount, imageCveCount, altSize, imageSize }: Props = $props();
 
-const benefits = [
-  {
-    title: `${cveReductionPercent?.toFixed(0) ?? 0}% Fewer Vulnerabilities`,
-    description: `Only ${altCveCount ?? 0} CVE vs ${imageCveCount ?? 0}`,
-    show: cveReductionPercent !== undefined,
-  },
-  {
-    title: `${sizeReductionPercent?.toFixed(0) ?? 0}% Smaller Image Size`,
-    description: `${filesize(altSize ?? 0)} vs ${filesize(imageSize ?? 0)}`,
-    show: sizeReductionPercent !== undefined,
-  },
+const benefits = $derived([
+  ...(!!cveReductionPercent && cveReductionPercent > 0
+    ? [
+        {
+          title: `${cveReductionPercent?.toFixed(0) ?? 0}% Fewer Vulnerabilities`,
+          description: `Only ${altCveCount ?? 0} CVE vs ${imageCveCount ?? 0}`,
+          show: cveReductionPercent !== undefined,
+        },
+      ]
+    : []),
+  ...(!!sizeReductionPercent && sizeReductionPercent > 0
+    ? [
+        {
+          title: `${sizeReductionPercent?.toFixed(0) ?? 0}% Smaller Image Size`,
+          description: `${filesize(altSize ?? 0)} vs ${filesize(imageSize ?? 0)}`,
+          show: sizeReductionPercent !== undefined,
+        },
+      ]
+    : []),
   {
     title: 'Enterprise-Grade Security',
     description: 'FIPS-compliant with continuous scanning',
@@ -34,7 +42,7 @@ const benefits = [
     description: 'Distroless with essential components only',
     show: true,
   },
-];
+]);
 </script>
 
 <div class="bg-[var(--pd-content-card-bg)] rounded-lg border border-[var(--pd-content-card-border)] p-5">
@@ -76,7 +84,7 @@ const benefits = [
     <!-- Right: Evaluation Criteria -->
     <div class="space-y-3">
       <!-- Image Size Comparison -->
-      {#if sizeReductionPercent !== undefined && altSize !== undefined && imageSize !== undefined}
+      {#if sizeReductionPercent !== undefined && sizeReductionPercent > 0 && altSize !== undefined && imageSize !== undefined}
         <div>
           <div class="flex justify-between items-center mb-1">
             <span class="text-xs text-[var(--pd-content-text)]">Image Size</span>
@@ -96,7 +104,7 @@ const benefits = [
       {/if}
 
       <!-- CVE Count Comparison -->
-      {#if cveReductionPercent !== undefined && altCveCount !== undefined && imageCveCount !== undefined}
+      {#if cveReductionPercent !== undefined && cveReductionPercent > 0 && altCveCount !== undefined && imageCveCount !== undefined}
         <div>
           <div class="flex justify-between items-center mb-1">
             <span class="text-xs text-[var(--pd-content-text)]">CVE Count</span>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.spec.ts
@@ -47,3 +47,16 @@ test('Expect that ReportImageCard displays reduction info for Hummingbird', asyn
 
   expect(screen.getByText('(-40%)')).toBeInTheDocument();
 });
+
+test('Expect that ReportImageCard hides reduction info when it is not positive', async () => {
+  render(ReportImageCard, {
+    title: 'hummingbird-image',
+    subtitle: 'Hummingbird hardened image',
+    version: 'latest',
+    size: '120 MB',
+    sizeReductionPercent: -20,
+    isHummingbird: true,
+  });
+
+  expect(screen.queryByText('(-20%)')).not.toBeInTheDocument();
+});

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/ReportImageCard.svelte
@@ -72,7 +72,7 @@ let {
       <span class="text-xs text-[var(--pd-content-text)] opacity-50 uppercase tracking-wide">Size</span>
       <span class="text-sm text-[var(--pd-content-header)]">
         {size}
-        {#if isHummingbird && sizeReductionPercent !== undefined}
+        {#if isHummingbird && sizeReductionPercent !== undefined && sizeReductionPercent > 0}
           <span class="text-xs text-purple-400 font-medium">(-{sizeReductionPercent.toFixed(0)}%)</span>
         {/if}
       </span>


### PR DESCRIPTION
##  Description

There are a few scenarios where the Hummingbird image _may_ be slightly bigger, or have more CVE(s), let's handle those case in the UI.

## Screenshots

### `docker.io/alpine/curl` smaller than `quay.io/hummingbird/curl`

1. Alternative table

<img width="931" height="72" alt="image" src="https://github.com/user-attachments/assets/f41d1c89-ab83-4a88-9f11-e26f78f72244" />

2. Report page

<img width="1211" height="774" alt="image" src="https://github.com/user-attachments/assets/fff001e0-4ad0-4f49-a39c-226f9a1bfd97" />

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/246
Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/262

- [x] unit tests have been added