### PR TITLE
feat(alt-table): responsive design

### DIFF
--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -38,7 +38,7 @@ let columns = $derived([
   new TableColumn<Row>('', {
     width: '2fr',
     renderer: NameColumn,
-    overflow: true,
+    overflow: false,
   }),
   ...(isGrypeInstalled
     ? [
@@ -48,7 +48,6 @@ let columns = $derived([
           align: 'center',
           renderMapping: (row: Row): Promise<LocalImageAlternativeReport> | undefined =>
             'report' in row ? row.report : undefined,
-          overflow: true,
         }),
         new TableColumn<Row, Promise<LocalImageAlternativeReport> | undefined>('Size Reduction', {
           width: '1fr',
@@ -56,7 +55,6 @@ let columns = $derived([
           align: 'center',
           renderMapping: (row: Row): Promise<LocalImageAlternativeReport> | undefined =>
             'report' in row ? row.report : undefined,
-          overflow: true,
         }),
       ]
     : []),

--- a/packages/frontend/src/routes/alternatives/(components)/columns/NameColumn.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/NameColumn.svelte
@@ -9,12 +9,12 @@ let { object }: Props = $props();
 </script>
 
 {#if 'report' in object}
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 w-full overflow-hidden">
     <span class="text-base">
       {object.localImage.name}:{object.localImage.tag}
     </span>
     <span class="text-[var(--pd-content-text)] opacity-30">→</span>
-    <span class="text-base text-purple-400">
+    <span class="text-base text-purple-400 overflow-hidden text-ellipsis">
       quay.io/hummingbird/{object.alternative.name}
     </span>
   </div>

--- a/packages/frontend/src/routes/alternatives/(components)/cves/SimpleLocalImageAlternativeReport.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/cves/SimpleLocalImageAlternativeReport.svelte
@@ -30,7 +30,7 @@ let reductionPercent = $derived.by(() => {
     <span class="text-base font-semibold text-green-400">{object.alternative.vulnerabilities.total}</span>
   </div>
   {#if reduction !== undefined && reduction > 0}
-    <div class="flex items-center gap-1">
+    <div class="flex items-center gap-1 max-lg:hidden">
       <span class="text-base text-[var(--pd-content-text)]">{reduction} CVEs eliminated</span>
       {#if reductionPercent !== undefined}
         <span class="text-base text-[var(--pd-content-text)]">({reductionPercent}%)</span>

--- a/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.svelte
@@ -22,7 +22,9 @@ let reductionPercent = $derived.by(() => {
 
 let saved = $derived.by(() => {
   if (!reduction || reduction <= 0) return undefined;
-  return filesize(reduction);
+  return filesize(reduction, {
+    round: 0,
+  });
 });
 
 let result: 'smaller' | 'larger' | 'equal' | undefined = $derived.by(() => {
@@ -37,13 +39,18 @@ let result: 'smaller' | 'larger' | 'equal' | undefined = $derived.by(() => {
 {#if valid}
   <div class="flex flex-col items-center">
     <div class="flex items-center gap-2">
-      <span class="text-base font-medium">{filesize(object.localImage.size)}</span>
+      <span class="text-base font-medium"
+        >{filesize(object.localImage.size, {
+          round: 0,
+        })}</span>
       <span class="text-[var(--pd-content-text)] opacity-30">→</span>
       <span class:text-green-400={result === 'smaller'} class="text-base font-medium"
-        >{filesize(object.alternative.size)}</span>
+        >{filesize(object.alternative.size, {
+          round: 0,
+      })}</span>
     </div>
     {#if result === 'smaller'}
-      <div class="flex items-center gap-1">
+      <div class="flex items-center gap-1 max-lg:hidden">
         <span class="text-sm text-green-400">-{reductionPercent}% smaller</span>
         <span class="text-xs text-[var(--pd-content-text)] opacity-50">({saved} saved)</span>
       </div>

--- a/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/filesize/FilesizeLocalImageAlternativeReport.svelte
@@ -47,7 +47,7 @@ let result: 'smaller' | 'larger' | 'equal' | undefined = $derived.by(() => {
       <span class:text-green-400={result === 'smaller'} class="text-base font-medium"
         >{filesize(object.alternative.size, {
           round: 0,
-      })}</span>
+        })}</span>
     </div>
     {#if result === 'smaller'}
       <div class="flex items-center gap-1 max-lg:hidden">


### PR DESCRIPTION
## Description

Make the table responsive, the CVE and Size reduction column get their sub-text hidden to avoid lot of clipped content

## Screenshots

1. Small

<img width="993" height="774" alt="image" src="https://github.com/user-attachments/assets/78aa6e99-db9d-403c-9743-c7d01423a1e6" />

3. Big

<img width="1304" height="774" alt="image" src="https://github.com/user-attachments/assets/7946b258-de11-47ee-804c-f7b072cc8871" />

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/265