### PR TITLE
fix(alt-table): adding key function to distinct items

### DIFF
--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -74,6 +74,14 @@ const row: TableRow<Row> = new TableRow<Row>({
     return [];
   },
 });
+
+function key(row: Row): string {
+  if ('report' in row) {
+    return `${row.localImage.engineId}:${row.localImage.id}`;
+  } else {
+    return `${row.engineId}:${row.id}`;
+  }
+}
 </script>
 
-<Table kind="alternatives" data={data} columns={columns} row={row} />
+<Table key={key} kind="alternatives" data={data} columns={columns} row={row} />


### PR DESCRIPTION
## Description

By default the table use the `name` of the row, but with multiple engines, you may have multiple time the same image in different machine, leading to glitch.

To distinct them properly, adding the key function, which given a row, return a unique key, based on the engineId and the id of the row.

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/263