### PR TITLE
fix: specify pod for cloned container

### DIFF
--- a/packages/backend/src/apis/container-api-impl.ts
+++ b/packages/backend/src/apis/container-api-impl.ts
@@ -60,12 +60,18 @@ export class ContainerApiImpl extends ContainerApi {
       await containerEngineAPI.stopContainer(engineId, containerId);
     }
 
+    const pods = await containerEngineAPI.listPods();
+    const pod = pods.find(
+      pod => pod.engineId === container.engineId && pod.Containers.some(container => container.Id === containerId),
+    );
+
     // Clone the container with the alternative image
     return await this.podmanService.clone(engineId, containerId, alternativeImage, {
       ...options,
       task: {
         title: `Cloning container ${container.Name} (${container.Id.substring(0, 8)})`,
       },
+      pod: pod?.Id,
     });
   }
 }

--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -155,6 +155,7 @@ describe('clone', () => {
       task: {
         title: 'Cloning container',
       },
+      pod: 'pod-id',
     });
 
     expect(windowAPI.withProgress).toHaveBeenCalledExactlyOnceWith(
@@ -189,6 +190,7 @@ describe('clone', () => {
       {
         image: 'alt-image',
         name: 'new-name',
+        pod: 'pod-id',
       },
     );
 

--- a/packages/backend/src/services/podman-service.ts
+++ b/packages/backend/src/services/podman-service.ts
@@ -76,6 +76,7 @@ export class PodmanService implements Disposable {
       task: {
         title: string;
       };
+      pod?: string;
     },
   ): Promise<{
     engineId: string;
@@ -112,6 +113,7 @@ export class PodmanService implements Disposable {
             {
               image: alternative,
               name: options.name,
+              pod: options.pod,
             },
           );
 


### PR DESCRIPTION
## Description

If a container is inside a pod, and you try to clone it, currently it will not be cloned inside the pod.

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/271