### PR TITLE
chore(dependabot): configure vitest update group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     schedule:
       interval: "daily"
       # check at 2am UTC
-      time: "02:00"      
+      time: "02:00"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
@@ -15,7 +15,7 @@ updates:
     schedule:
       interval: daily
       # check at 2am UTC
-      time: "02:00"      
+      time: "02:00"
     open-pull-requests-limit: 10
     groups:
       fortawesome:
@@ -27,3 +27,8 @@ updates:
         patterns:
           - "@tailwindcss/*"
           - "tailwindcss"
+      vitest:
+        applies-to: version-updates
+        patterns:
+          - "@vitest/*"
+          - "vitest"


### PR DESCRIPTION
## Description

Dependabot seem to have some issue updating vitest related packages; grouping together, similarly to https://github.com/podman-desktop/extension-podman-quadlet/pull/1394