### PR TITLE
chore(Containerfile): use ubi image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,25 @@
-FROM node:24-slim AS builder
+#
+# Copyright (C) 2026 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# tag 10.1-1764649731
+FROM registry.access.redhat.com/ubi10/nodejs-24@sha256:dd07ba12178fe2b929c81461e9bb7a4cd41e4b255fd46209f5a293daa85efec2 AS builder
+
+USER 0
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN npm i -g corepack@0.31.0 && corepack enable


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/224

Image I built locally `quay.io/rh-ee-astefani/extension-hummingbird:demo`