### PR TITLE
fix(ci): release.yaml missing step id

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,7 @@ jobs:
           tag: ${{ needs.tag.outputs.extVersion }} latest
           artifact-id: ${{ needs.build-oci.outputs.artifact-id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.run_id }}
 
   release:
     needs: [tag, publish-oci]


### PR DESCRIPTION
We need to specify the run-id for downloading the artifact apparently, it weirdly default to `NaN` otherwise

See https://github.com/redhat-developer/podman-desktop-hummingbird-ext/actions/runs/24464248510/job/71486896586