### PR TITLE
fix(ci): release.yaml use version tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,7 +147,7 @@ jobs:
           registry: 'ghcr.io'
           registry-username: ${{ github.repository_owner }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ needs.tag.outputs.extVersion }} latest
+          tag: ${{ needs.tag.outputs.extVersion }}
           artifact-id: ${{ needs.build-oci.outputs.artifact-id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.run_id }}


### PR DESCRIPTION
The `podman-desktop/gh-extensions-actions/.github/actions/oci-publish@19efb8f2422c54ad8904ad068ad363bcabaacc96` action does not support multiple tags currrently