### PR TITLE
fix(clone): use alt image cmd & entrypoint

### DIFF
--- a/__mocks__/@podman-desktop/api.ts
+++ b/__mocks__/@podman-desktop/api.ts
@@ -100,6 +100,7 @@ const plugin = {
     onEvent: vi.fn(),
     pullImage: vi.fn(),
     replicatePodmanContainer: vi.fn(),
+    getImageInspect: vi.fn(),
   } as unknown as typeof podmanDesktopApi.containerEngine,
   configuration: {} as unknown as typeof podmanDesktopApi.configuration,
   authentication: {} as unknown as typeof podmanDesktopApi.authentication,

--- a/packages/backend/src/services/podman-service.spec.ts
+++ b/packages/backend/src/services/podman-service.spec.ts
@@ -21,6 +21,7 @@ import type {
   ContainerEngineInfo,
   TelemetryLogger,
   CancellationToken,
+  ImageInspectInfo,
 } from '@podman-desktop/api';
 import {
   extensions as extensionsAPI,
@@ -71,12 +72,20 @@ const CANCELLATION_TOKEN_MOCK: CancellationToken = {
   isCancellationRequested: false,
 } as CancellationToken;
 
+const IMAGE_INSPECT_MOCK = {
+  Config: {
+    Entrypoint: ['entrypoint'],
+    Cmd: ['command'],
+  },
+} as unknown as ImageInspectInfo;
+
 beforeEach(() => {
   vi.resetAllMocks();
 
   vi.mocked(extensionsAPI.getExtension).mockReturnValue(PODMAN_EXTENSION_MOCK);
   vi.mocked(PROVIDER_SERVICE_MOCK.getContainerConnections).mockReturnValue([STARTED_PROVIDER_CONNECTION_MOCK]);
   vi.mocked(containerEngineAPI.listInfos).mockResolvedValue([ENGINE_INFO_MOCK]);
+  vi.mocked(containerEngineAPI.getImageInspect).mockResolvedValue(IMAGE_INSPECT_MOCK);
   vi.mocked(windowAPI.withProgress).mockImplementation(async (_, task) => {
     return task({ report: vi.fn() }, CANCELLATION_TOKEN_MOCK);
   });
@@ -191,6 +200,8 @@ describe('clone', () => {
         image: 'alt-image',
         name: 'new-name',
         pod: 'pod-id',
+        entrypoint: IMAGE_INSPECT_MOCK.Config.Entrypoint,
+        command: IMAGE_INSPECT_MOCK.Config.Cmd,
       },
     );
 

--- a/packages/backend/src/services/podman-service.ts
+++ b/packages/backend/src/services/podman-service.ts
@@ -100,6 +100,7 @@ export class PodmanService implements Disposable {
 
           // Pull the image
           await containerEngineAPI.pullImage(connection.connection, alternative, console.debug, undefined, token);
+          const alternativeInspect = await containerEngineAPI.getImageInspect(engineId, alternative);
 
           // Replicate the podman container
           const result = await containerEngineAPI.replicatePodmanContainer(
@@ -114,6 +115,8 @@ export class PodmanService implements Disposable {
               image: alternative,
               name: options.name,
               pod: options.pod,
+              entrypoint: alternativeInspect.Config.Entrypoint,
+              command: alternativeInspect.Config.Cmd,
             },
           );
 


### PR DESCRIPTION
## Descrption

When cloning an image we are also cloning its Entrypoint and CMD,  but for some images like `nginx` it is not the same, so the cloned image will never start.

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/297