### PR TITLE
fix: resolve CVE-2026-33750 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
       "rollup": "^4.59.0",
       "flatted": "^3.4.2",
       "ajv@^6": "^6.14.0",
-      "ajv@>=7": ">=8.18.0"
+      "ajv@>=7": ">=8.18.0",
+      "brace-expansion@^1": "^1.1.13"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   flatted: ^3.4.2
   ajv@^6: ^6.14.0
   ajv@>=7: '>=8.18.0'
+  brace-expansion@^1: ^1.1.13
 
 importers:
 
@@ -1655,8 +1656,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
@@ -5175,7 +5176,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -6371,7 +6372,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@9.0.9:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-33750 in `brace-expansion`.

**Advisory**: brace-expansion: Zero-step sequence causes process hang and memory exhaustion
**Vulnerable versions**: <1.1.13
**Patched versions**: >=1.1.13
**Advisory URL**: https://github.com/advisories/GHSA-f886-m6hf-6m8v

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-33750: _brace-expansion: Zero-step sequence causes process hang and memory exhaustion_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-33750 is no longer reported