### PR TITLE
fix: resolve CVE-2024-47764 in cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
       "flatted": "^3.4.2",
       "ajv@^6": "^6.14.0",
       "ajv@>=7": ">=8.18.0",
-      "brace-expansion@^1": "^1.1.13"
+      "brace-expansion@^1": "^1.1.13",
+      "cookie": "0.7.0"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   ajv@^6: ^6.14.0
   ajv@>=7: '>=8.18.0'
   brace-expansion@^1: ^1.1.13
+  cookie: 0.7.0
 
 importers:
 
@@ -1789,8 +1790,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+  cookie@0.7.0:
+    resolution: {integrity: sha512-qCf+V4dtlNhSRXGAZatc1TasyFO6GjohcOul807YOb5ik3+kQSnb4d7iajeCL8QHaJ4uZEjCgiCJerKXwdRVlQ==}
     engines: {node: '>= 0.6'}
 
   core-js-compat@3.49.0:
@@ -4460,7 +4461,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@8.0.9(@types/node@25.2.0)(esbuild@0.27.2)(jiti@2.6.1)(yaml@2.8.3))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
-      cookie: 0.6.0
+      cookie: 0.7.0
       devalue: 5.7.1
       esm-env: 1.2.2
       kleur: 4.1.5
@@ -5311,7 +5312,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.6.0: {}
+  cookie@0.7.0: {}
 
   core-js-compat@3.49.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix low severity vulnerability CVE-2024-47764 in `cookie`.

**Advisory**: cookie accepts cookie name, path, and domain with out of bounds characters
**Vulnerable versions**: <0.7.0
**Patched versions**: >=0.7.0
**Advisory URL**: https://github.com/advisories/GHSA-pxg6-pf52-xh8x

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2024-47764: _cookie accepts cookie name, path, and domain with out of bounds characters_

### How to test this PR?

Run `pnpm audit` and verify CVE-2024-47764 is no longer reported