### PR TITLE
chore(navbar): fix alignment

### DIFF
--- a/packages/frontend/src/lib/navigations/Navigation.svelte
+++ b/packages/frontend/src/lib/navigations/Navigation.svelte
@@ -17,12 +17,8 @@ import ImageIcon from '$lib/icons/ImageIcon.svelte';
       </p>
     </a>
   </div>
-  <div class="h-full overflow-y-auto" style="margin-bottom:auto">
-    <!-- FontAwesome icons rendered via SettingsNavItem are slightly narrower than custom Svelte component icons
-             (which get wrapped in a <span> by the Icon component). The pl-[1px] compensates for this alignment difference. -->
-    <div class="pl-[1px]">
-      <SettingsNavItem title="Catalog" icon={faHouse} selected={page.url.pathname === '/'} href={resolve('/')} />
-    </div>
+  <div class="h-full overflow-y-auto [&_svg]:w-[1.25em] [&_span[role=img]]:w-[1.25em]" style="margin-bottom:auto">
+    <SettingsNavItem title="Catalog" icon={faHouse} selected={page.url.pathname === '/'} href={resolve('/')} />
 
     <SettingsNavItem
       title="Alternatives"


### PR DESCRIPTION
chore(navbar): fix alignment

Fixes the alignment for hummingbird navbar.


Before:

<img width="312" height="398" alt="Screenshot 2026-05-18 at 9 47 48 PM" src="https://github.com/user-attachments/assets/29d34bb8-a8ff-42a0-81b0-f2e4dbf27714" />

After:
<img width="312" height="398" alt="Screenshot 2026-05-18 at 9 52 49 PM" src="https://github.com/user-attachments/assets/7b2e1eaf-4904-4c8d-983e-1fd4498e9ea4" />



Signed-off-by: Charlie Drage <charlie@charliedrage.com>
