### PR TITLE
chore: overrides shell-quote version to >=1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
       "brace-expansion@^1": "^1.1.13",
       "cookie": "0.7.0",
       "postcss": "^8.5.12",
-      "shell-quote": ">=1.8.4"
+      "concurrently>shell-quote": ">=1.8.4"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
       "ajv@>=7": ">=8.18.0",
       "brace-expansion@^1": "^1.1.13",
       "cookie": "0.7.0",
-      "postcss": "^8.5.12"
+      "postcss": "^8.5.12",
+      "shell-quote": ">=1.8.4"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   brace-expansion@^1: ^1.1.13
   cookie: 0.7.0
   postcss: ^8.5.12
-  shell-quote: '>=1.8.4'
+  concurrently>shell-quote: '>=1.8.4'
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   brace-expansion@^1: ^1.1.13
   cookie: 0.7.0
   postcss: ^8.5.12
+  shell-quote: '>=1.8.4'
 
 importers:
 
@@ -3188,8 +3189,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   should-equal@2.0.0:
@@ -5303,7 +5304,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -6827,7 +6828,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   should-equal@2.0.0:
     dependencies:


### PR DESCRIPTION
## Description

Addressing `shell-quote` https://github.com/ljharb/shell-quote/security/advisories/GHSA-w7jw-789q-3m8p

[shell-quote](https://github.com/ljharb/shell-quote) usage originate from the [concurrently](https://github.com/open-cli-tools/concurrently) library, which is only used in dev environment.

```bash
$ pnpm why shell-quote
Legend: production dependency, optional only, dev only

hummingbird@0.1.0-next /[...]/podman-desktop-extension-hummingbird (PRIVATE)

devDependencies:
concurrently 9.2.1
└── shell-quote 1.8.3
``` 

## Upstream

The concurrency repository has been updated (https://github.com/open-cli-tools/concurrently/pull/591) but no release has been made.

I created an upstream issue https://github.com/open-cli-tools/concurrently/issues/592 to keep track, and if concurrently is getting updated we should remove the override.

