### PR TITLE
fix: resolve CVE-2026-45149 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       "ajv@^6": "^6.14.0",
       "ajv@>=7": ">=8.18.0",
       "brace-expansion@^1": "^1.1.13",
+      "brace-expansion@^5": ">=5.0.6",
       "cookie": "0.7.0",
       "postcss": "^8.5.12"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   ajv@^6: ^6.14.0
   ajv@>=7: '>=8.18.0'
   brace-expansion@^1: ^1.1.13
+  brace-expansion@^5: '>=5.0.6'
   cookie: 0.7.0
   postcss: ^8.5.12
 
@@ -1657,8 +1658,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5190,7 +5191,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6383,7 +6384,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-45149 in `brace-expansion`.

**Advisory**: brace-expansion: Large numeric range defeats documented `max` DoS protection
**Vulnerable versions**: >=5.0.0 <5.0.6
**Patched versions**: >=5.0.6
**Advisory URL**: https://github.com/advisories/GHSA-jxxr-4gwj-5jf2

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-45149: _brace-expansion: Large numeric range defeats documented `max` DoS protection_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-45149 is no longer reported