### PR TITLE
chore(package.json): remove no long necessary concurrently>shell-quote override

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
       "brace-expansion@^5": ">=5.0.6",
       "cookie": "0.7.0",
       "postcss": "^8.5.12",
-      "concurrently>shell-quote": ">=1.8.4",
       "esbuild": ">=0.28.1",
       "js-yaml": ">=4.2.0",
       "dompurify": ">=3.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ overrides:
   brace-expansion@^5: '>=5.0.6'
   cookie: 0.7.0
   postcss: ^8.5.12
-  concurrently>shell-quote: '>=1.8.4'
   esbuild: '>=0.28.1'
   js-yaml: '>=4.2.0'
   dompurify: '>=3.4.11'


### PR DESCRIPTION
## Description

Following https://github.com/redhat-developer/podman-desktop-hummingbird-ext/pull/414, the concurrently lib now include the version of `shell-quote` with the vulnerability fix