### PR TITLE
fix: resolve CVE-2026-53550 in js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
       "cookie": "0.7.0",
       "postcss": "^8.5.12",
       "concurrently>shell-quote": ">=1.8.4",
-      "esbuild": ">=0.28.1"
+      "esbuild": ">=0.28.1",
+      "js-yaml": ">=4.2.0"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,7 @@ overrides:
   postcss: ^8.5.12
   concurrently>shell-quote: '>=1.8.4'
   esbuild: '>=0.28.1'
+  js-yaml: '>=4.2.0'
 
 importers:
 
@@ -2431,10 +2432,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -3905,7 +3902,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6023,10 +6020,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.2.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability CVE-2026-53550 in `js-yaml`.

**Advisory**: JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases
**Vulnerable versions**: <=4.1.1
**Patched versions**: >=4.2.0
**Advisory URL**: https://github.com/advisories/GHSA-h67p-54hq-rp68

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-53550: _JS-YAML: Quadratic-complexity DoS in merge key handling via repeated aliases_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-53550 is no longer reported