### PR TITLE
fix: resolve GHSA-vxr8-fq34-vvx9 in dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
       "postcss": "^8.5.12",
       "concurrently>shell-quote": ">=1.8.4",
       "esbuild": ">=0.28.1",
-      "js-yaml": ">=4.2.0"
+      "js-yaml": ">=4.2.0",
+      "dompurify": ">=3.4.9"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,7 @@ overrides:
   concurrently>shell-quote: '>=1.8.4'
   esbuild: '>=0.28.1'
   js-yaml: '>=4.2.0'
+  dompurify: '>=3.4.9'
 
 importers:
 
@@ -1789,8 +1790,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -5268,7 +5269,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.8:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7338,7 +7339,7 @@ snapshots:
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       dayjs: 1.11.21
-      dompurify: 3.4.8
+      dompurify: 3.4.10
       nanoid: 5.1.11
       tailwind-merge: 3.6.0
 


### PR DESCRIPTION
### What does this PR do?

Fix low severity vulnerability GHSA-vxr8-fq34-vvx9 in `dompurify`.

**Advisory**: DOMPurify: Trusted Types policy survives `clearConfig()` and can poison later `RETURN_TRUSTED_TYPE` output
**Vulnerable versions**: <3.4.9
**Patched versions**: >=3.4.9
**Advisory URL**: https://github.com/advisories/GHSA-vxr8-fq34-vvx9

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-vxr8-fq34-vvx9: _DOMPurify: Trusted Types policy survives `clearConfig()` and can poison later `RETURN_TRUSTED_TYPE` output_

### How to test this PR?

Run `pnpm audit` and verify GHSA-vxr8-fq34-vvx9 is no longer reported