### PR TITLE
fix: resolve CVE-2026-12151 in undici

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
       "esbuild": ">=0.28.1",
       "js-yaml": ">=4.2.0",
       "dompurify": ">=3.4.9",
-      "undici@>=7": ">=7.28.0 <8"
+      "undici@>=7": ">=7.28.0 <8",
+      "undici@^6": ">=6.27.0 <7"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   js-yaml: '>=4.2.0'
   dompurify: '>=3.4.9'
   undici@>=7: '>=7.28.0 <8'
+  undici@^6: '>=6.27.0 <7'
 
 importers:
 
@@ -3394,8 +3395,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.28.0:
@@ -3698,17 +3699,17 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.8
       '@octokit/request-error': 7.1.0
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@actions/http-client@4.0.0':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
@@ -7003,7 +7004,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-12151 in `undici`.

**Advisory**: undici WebSocket client vulnerable to denial of service via fragment count bypass
**Vulnerable versions**: <6.27.0
**Patched versions**: >=6.27.0
**Advisory URL**: https://github.com/advisories/GHSA-vxpw-j846-p89q

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-12151: _undici WebSocket client vulnerable to denial of service via fragment count bypass_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-12151 is no longer reported