### PR TITLE
fix: prevent layout redirect to root on webview reload

### DIFF
--- a/packages/frontend/src/routes/+layout.svelte
+++ b/packages/frontend/src/routes/+layout.svelte
@@ -12,7 +12,7 @@ import Navigation from '$lib/navigations/Navigation.svelte';
 let { children } = $props();
 
 const state = await getRouterState();
-if (state.url !== page.url.pathname) {
+if (state.url !== '/' && state.url !== page.url.pathname) {
   // eslint-disable-next-line svelte/no-navigation-without-resolve
   goto(state.url).catch(console.error);
 }


### PR DESCRIPTION
When the webview reloads, the router state URL defaults to '/'. Previously this caused an unnecessary redirect back to root, discarding the current page. Skip the redirect when the saved state URL is '/' so the user stays on the page they were viewing.