### PR TITLE
fix(frontend): container provider select text overflow

### DIFF
--- a/packages/frontend/src/lib/selects/ContainerProviderConnectionSelect.svelte
+++ b/packages/frontend/src/lib/selects/ContainerProviderConnectionSelect.svelte
@@ -59,16 +59,20 @@ function getProviderStatusColor(item: ProviderContainerConnectionDetailedInfo): 
     label: containerProviderConnection.name,
   }))}>
   <div slot="item" let:item>
-    <div class="flex items-center">
-      <div class="flex w-2 h-2 me-2 rounded-full {getProviderStatusColor(item)}"></div>
-      <div class="grow">
-        <span>{item.name}</span>
+    <div class="flex items-center w-full">
+      <div class="w-2 h-2 min-w-2 me-2 rounded-full {getProviderStatusColor(item)}"></div>
+
+      <div class="flex-1 min-w-0">
+        <span class="block truncate">
+          {item.name}
+        </span>
       </div>
-      <div>
-        {#if item.vmType}
+
+      {#if item.vmType}
+        <div class="flex-shrink-0 ms-2">
           ({item.vmType})
-        {/if}
-      </div>
+        </div>
+      {/if}
     </div>
   </div>
 </Select>


### PR DESCRIPTION
## Description

When the provider name is very long, the sizing of the select box was a bit messy, we can fix this by some css tweak 

## Screenshots

| Before | After |
| --- | --- |
| <img width="956" height="774" alt="image" src="https://github.com/user-attachments/assets/1756b0b8-e1f0-4fbd-b23e-25f24b03aa48" /> | <img width="956" height="774" alt="image" src="https://github.com/user-attachments/assets/b0e28899-b6b0-4a92-948b-95fde66002ef" /> |

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/296

## Testing

1. Create a podman machine with a long name

```
$: https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/296
```

2. Go to Hummingbird, assert this is displaying nicely now