### PR TITLE
fix(frontend): alternative skeleton columns

### DIFF
--- a/packages/frontend/src/routes/alternatives/+page.svelte
+++ b/packages/frontend/src/routes/alternatives/+page.svelte
@@ -21,8 +21,12 @@ onMount(() => {
 
 let columns = $derived([
   {
-    name: 'Original Image',
-    width: '1.5fr',
+    name: 'Status',
+    width: '70px',
+  },
+  {
+    name: '',
+    width: '2fr',
   },
   ...(data.isGrypeInstalled
     ? [
@@ -36,6 +40,10 @@ let columns = $derived([
         },
       ]
     : []),
+  {
+    name: 'Actions',
+    width: '50px',
+  },
 ]);
 </script>
 

--- a/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, within } from '@testing-library/svelte';
+import { cleanup, render, within } from '@testing-library/svelte';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { LocalImageAlternative } from '@podman-desktop/extension-hummingbird-core-api';
@@ -87,6 +87,41 @@ describe('loading', () => {
     const skeletons = getByRole('table', { name: 'loading' });
     expect(skeletons).toBeInTheDocument();
   });
+
+  test.each([true, false])(
+    'skeleton table columns should match alternatives table columns (isGrypeInstalled: %s)',
+    async (isGrypeInstalled) => {
+      const { getByRole: getSkeletonRole } = render(Page, {
+        data: {
+          alternatives: new Promise<Array<LocalImageAlternative>>(vi.fn()),
+          isGrypeInstalled,
+        },
+        params: {},
+      });
+
+      const skeletonTable = getSkeletonRole('table', { name: 'loading' });
+      const skeletonHeaders = within(skeletonTable)
+        .getAllByRole('columnheader')
+        .map(el => el.textContent?.trim() ?? '');
+
+      cleanup();
+
+      const { getByRole } = render(Page, {
+        data: {
+          alternatives: Promise.resolve(ALTERNATIVES),
+          isGrypeInstalled,
+        },
+        params: {},
+      });
+
+      const alternativesTable = await vi.waitFor(() => getByRole('table', { name: 'alternatives' }));
+      const actualHeaders = within(alternativesTable)
+        .getAllByRole('columnheader')
+        .map(el => el.textContent?.trim() ?? '');
+
+      expect(skeletonHeaders).toEqual(actualHeaders);
+    },
+  );
 });
 
 describe('data', () => {

--- a/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
@@ -90,7 +90,7 @@ describe('loading', () => {
 
   test.each([true, false])(
     'skeleton table columns should match alternatives table columns (isGrypeInstalled: %s)',
-    async (isGrypeInstalled) => {
+    async isGrypeInstalled => {
       const { getByRole: getSkeletonRole } = render(Page, {
         data: {
           alternatives: new Promise<Array<LocalImageAlternative>>(vi.fn()),


### PR DESCRIPTION
## Description

Update the columns name in the alternative table

## Screenshots

**Before**

<img width="2536" height="398" alt="image" src="https://github.com/user-attachments/assets/54ad6963-8c7c-47c1-8fa2-eab40f7012e5" />

**After**

<img width="1464" height="251" alt="image" src="https://github.com/user-attachments/assets/628f94f4-5f3b-4ad4-b7c7-87d4c5784846" />


## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/464