### PR TITLE
fix(frontend): hide clonable table when no containers are available

### DIFF
--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
@@ -1,5 +1,5 @@
 /**********************************************************************
- * Copyright (C) 2024 Red Hat, Inc.
+ * Copyright (C) 2024-2026 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,39 +18,68 @@
 
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/svelte';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 import RawReport from './RawReport.svelte';
-import type { AlternativeReport, ImageReport } from '@podman-desktop/extension-hummingbird-core-api';
+import type { AlternativeReport, ImageReport, LocalContainer } from '@podman-desktop/extension-hummingbird-core-api';
+
+const MOCK_ALTERNATIVE_MOCK: AlternativeReport = {
+  image: {
+    name: 'alt-image',
+    latest_tag: '1.0.0',
+  },
+  tags: [{ name: '1.0.0', sizes: { amd64: 50000000 } }],
+  vulnerabilities: {
+    summary: { total: 5, critical: 0, high: 1, medium: 2, low: 2 },
+  },
+} as unknown as AlternativeReport;
+
+const IMAGE_REPORT_MOCK: ImageReport = {
+  inspect: {
+    RepoTags: ['original-image:latest'],
+    Size: 100000000,
+    Architecture: 'amd64',
+    Created: '2024-01-01T00:00:00Z',
+  },
+  vulnerabilities: { total: 20, critical: 2, high: 4, medium: 8, low: 6, negligible: 0, unknown: 0 },
+  containers: [],
+} as unknown as ImageReport;
 
 test('Expect that RawReport displays both image cards', async () => {
-  const alternative = {
-    image: {
-      name: 'alt-image',
-      latest_tag: '1.0.0',
-    },
-    tags: [{ name: '1.0.0', sizes: { amd64: 50000000 } }],
-    vulnerabilities: {
-      summary: { total: 5, critical: 0, high: 1, medium: 2, low: 2 },
-    },
-  };
-
-  const image = {
-    inspect: {
-      RepoTags: ['original-image:latest'],
-      Size: 100000000,
-      Architecture: 'amd64',
-      Created: '2024-01-01T00:00:00Z',
-    },
-    vulnerabilities: { total: 20, critical: 2, high: 4, medium: 8, low: 6 },
-    containers: [],
-  };
-
   render(RawReport, {
-    alternative: alternative as unknown as AlternativeReport,
-    image: image as unknown as ImageReport,
+    alternative: MOCK_ALTERNATIVE_MOCK,
+    image: IMAGE_REPORT_MOCK,
   });
 
   expect(screen.getByText('alt-image')).toBeInTheDocument();
   expect(screen.getByText('original-image:latest')).toBeInTheDocument();
   expect(screen.getByText('Hardened Alternative Found!')).toBeInTheDocument();
+});
+
+describe('ClonableContainerTable visibility', () => {
+  test('should not display container table when containers array is empty', async () => {
+    expect(IMAGE_REPORT_MOCK.containers).toHaveLength(0);
+
+    render(RawReport, {
+      alternative: MOCK_ALTERNATIVE_MOCK,
+      image: IMAGE_REPORT_MOCK,
+    });
+
+    expect(screen.queryByText(/Container.*using original-image:latest image/)).not.toBeInTheDocument();
+  });
+
+  test('should display container table and title when containers exist', async () => {
+    const containers: LocalContainer[] = [
+      { id: 'abcd1234', name: '/my-container', state: 'running' } as unknown as LocalContainer,
+    ];
+
+    render(RawReport, {
+      alternative: MOCK_ALTERNATIVE_MOCK,
+      image: {
+        ...IMAGE_REPORT_MOCK,
+        containers,
+      },
+    });
+
+    expect(screen.getByText(/Container using original-image:latest image/)).toBeInTheDocument();
+  });
 });

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
@@ -17,7 +17,7 @@
  ***********************************************************************/
 
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { describe, expect, test } from 'vitest';
 import RawReport from './RawReport.svelte';
 import type { AlternativeReport, ImageReport, LocalContainer } from '@podman-desktop/extension-hummingbird-core-api';
@@ -45,34 +45,23 @@ const IMAGE_REPORT_MOCK: ImageReport = {
 } as unknown as ImageReport;
 
 test('Expect that RawReport displays both image cards', async () => {
-  render(RawReport, {
+  const { getByText } = render(RawReport, {
     alternative: MOCK_ALTERNATIVE_MOCK,
     image: IMAGE_REPORT_MOCK,
   });
 
-  expect(screen.getByText('alt-image')).toBeInTheDocument();
-  expect(screen.getByText('original-image:latest')).toBeInTheDocument();
-  expect(screen.getByText('Hardened Alternative Found!')).toBeInTheDocument();
+  expect(getByText('alt-image')).toBeInTheDocument();
+  expect(getByText('original-image:latest')).toBeInTheDocument();
+  expect(getByText('Hardened Alternative Found!')).toBeInTheDocument();
 });
 
 describe('ClonableContainerTable visibility', () => {
-  test('should not display container table when containers array is empty', async () => {
-    expect(IMAGE_REPORT_MOCK.containers).toHaveLength(0);
-
-    render(RawReport, {
-      alternative: MOCK_ALTERNATIVE_MOCK,
-      image: IMAGE_REPORT_MOCK,
-    });
-
-    expect(screen.queryByText(/Container.*using original-image:latest image/)).not.toBeInTheDocument();
-  });
-
   test('should display container table and title when containers exist', async () => {
     const containers: LocalContainer[] = [
       { id: 'abcd1234', name: '/my-container', state: 'running' } as unknown as LocalContainer,
     ];
 
-    render(RawReport, {
+    const { getByText } = render(RawReport, {
       alternative: MOCK_ALTERNATIVE_MOCK,
       image: {
         ...IMAGE_REPORT_MOCK,
@@ -80,6 +69,17 @@ describe('ClonableContainerTable visibility', () => {
       },
     });
 
-    expect(screen.getByText(/Container using original-image:latest image/)).toBeInTheDocument();
+    expect(getByText('Container using original-image:latest image')).toBeInTheDocument();
+  });
+
+  test('should not display container table when containers array is empty', async () => {
+    expect(IMAGE_REPORT_MOCK.containers).toHaveLength(0);
+
+    const { queryByText  } = render(RawReport, {
+      alternative: MOCK_ALTERNATIVE_MOCK,
+      image: IMAGE_REPORT_MOCK,
+    });
+
+    expect(queryByText('Container using original-image:latest image')).not.toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.spec.ts
@@ -75,7 +75,7 @@ describe('ClonableContainerTable visibility', () => {
   test('should not display container table when containers array is empty', async () => {
     expect(IMAGE_REPORT_MOCK.containers).toHaveLength(0);
 
-    const { queryByText  } = render(RawReport, {
+    const { queryByText } = render(RawReport, {
       alternative: MOCK_ALTERNATIVE_MOCK,
       image: IMAGE_REPORT_MOCK,
     });

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/report/RawReport.svelte
@@ -94,11 +94,13 @@ const imageVersion = $derived(imageRepoTag.split(':')[1] ?? '-');
     imageSize={image.inspect.Size} />
 </div>
 
-<div class="px-5 pt-4">
-  <span class="text-base font-bold text-[var(--pd-content-header)]"
-    >Container{image.containers.length > 1 ? 's' : ''} using {image.inspect.RepoTags[0]} image</span>
-</div>
+{#if image.containers.length > 0}
+  <div class="px-5 pt-4">
+    <span class="text-base font-bold text-[var(--pd-content-header)]">
+      Container{image.containers.length > 1 ? 's' : ''} using {image.inspect.RepoTags[0]} image</span>
+  </div>
 
-<div class="flex w-full">
-  <ClonableContainerTable containers={image.containers} />
-</div>
+  <div class="flex w-full">
+    <ClonableContainerTable containers={image.containers} />
+  </div>
+{/if}


### PR DESCRIPTION
## Description

In the image report page, we have at the bottom, a table for the clonable containers, however the title "Container using <w> image" is always visible, making it weird, as nothing is shown bellow

## Screeshots

**Before**

<img width="513" height="183" alt="Image" src="https://github.com/user-attachments/assets/92a005cd-67be-4c94-9b92-1c7e07e9ed5c" />

**After**

<img width="746" height="177" alt="image" src="https://github.com/user-attachments/assets/ad1a9c08-4fc6-416e-b19e-4cba5554228c" />

<img width="842" height="163" alt="image" src="https://github.com/user-attachments/assets/755585f3-5c0b-4398-8a84-236c4de4600d" />

:bulb: You don't see the title if there is no containers to clone

## Related issues 

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/306

## Tests

- [x] tests have been added