### PR TITLE
feat(ContainerIcon): reflect container status

### DIFF
--- a/packages/backend/src/apis/container-api-impl.ts
+++ b/packages/backend/src/apis/container-api-impl.ts
@@ -38,6 +38,7 @@ export class ContainerApiImpl extends ContainerApi {
       id: container.Id,
       name: container.Name,
       imageID: container.Image,
+      state: container.State.Running ? 'running' : 'stopped',
     };
   }
 

--- a/packages/backend/src/services/alternative-service.ts
+++ b/packages/backend/src/services/alternative-service.ts
@@ -171,6 +171,7 @@ export class AlternativeService extends Publisher<void> implements AsyncInit, Di
         id: container.Id,
         name: container.Names[0],
         imageID: container.ImageID,
+        state: container.State,
       });
       accumulator.set(container.ImageID, array);
 
@@ -353,6 +354,7 @@ export class AlternativeService extends Publisher<void> implements AsyncInit, Di
             id: container.Id,
             name: container.Names[0],
             imageID: container.ImageID,
+            state: container.State,
           })),
       },
       alternative: alternative,

--- a/packages/frontend/src/lib/columns/ContainerStatus.spec.ts
+++ b/packages/frontend/src/lib/columns/ContainerStatus.spec.ts
@@ -1,0 +1,56 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+
+import ContainerStatus from './ContainerStatus.svelte';
+import type { LocalContainer } from '@podman-desktop/extension-hummingbird-core-api';
+
+test('should render status icon with uppercased state', () => {
+  const container: LocalContainer = {
+    id: 'container123',
+    engineId: 'podman',
+    name: 'my-container',
+    imageID: 'sha256:abc123',
+    state: 'running',
+  };
+
+  const { getByRole } = render(ContainerStatus, { object: container });
+
+  const status = getByRole('status');
+  expect(status).toBeInTheDocument();
+  expect(status.title).toBe('RUNNING');
+});
+
+test('should display exited state', () => {
+  const container: LocalContainer = {
+    id: 'container456',
+    engineId: 'podman',
+    name: 'stopped-container',
+    imageID: 'sha256:def456',
+    state: 'exited',
+  };
+
+  const { getByRole } = render(ContainerStatus, { object: container });
+
+  const status = getByRole('status');
+  expect(status.title).toBe('EXITED');
+});

--- a/packages/frontend/src/lib/columns/ContainerStatus.svelte
+++ b/packages/frontend/src/lib/columns/ContainerStatus.svelte
@@ -7,7 +7,7 @@ interface Props {
   object: LocalContainer;
 }
 
-let { object: _ }: Props = $props();
+let { object: container }: Props = $props();
 </script>
 
-<StatusIcon icon={ContainerIcon} />
+<StatusIcon icon={ContainerIcon} status={container.state.toUpperCase()} />

--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { TableColumn, Table, TableRow } from '@podman-desktop/ui-svelte';
 import type {
+  LocalContainer,
+  LocalImage,
   LocalImageAlternative,
   LocalImageAlternativeReport,
 } from '@podman-desktop/extension-hummingbird-core-api';
@@ -28,11 +30,11 @@ let data: Row[] = $derived(
 );
 
 let columns = $derived([
-  new TableColumn<Row, 'container' | 'image'>('Status', {
+  new TableColumn<Row, LocalContainer | LocalImage>('Status', {
     align: 'center',
     width: '70px',
     renderer: StatusColumn,
-    renderMapping: (row: Row): 'container' | 'image' => ('report' in row ? 'image' : 'container'),
+    renderMapping: (row: Row): LocalContainer | LocalImage => ('report' in row ? row.localImage : row),
     overflow: true,
   }),
   new TableColumn<Row>('', {

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
@@ -64,6 +64,7 @@ test('should display clone icon button for container row', () => {
     id: 'container123',
     engineId: 'podman',
     imageID: 'localhost/foo:bar',
+    state: 'running',
   };
 
   const { getByTitle } = render(ActionColumn, { object: containerRow });
@@ -134,6 +135,7 @@ test('should navigate to clone container when clone button is clicked', async ()
     id: 'container123',
     engineId: 'podman',
     imageID: 'localhost/foo:bar',
+    state: 'running',
   };
 
   const { getByTitle } = render(ActionColumn, { object: containerRow });

--- a/packages/frontend/src/routes/alternatives/(components)/columns/NameColumn.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/NameColumn.spec.ts
@@ -84,6 +84,7 @@ test('should display container name and ID', () => {
     id: 'container123456789',
     engineId: 'podman',
     imageID: 'sha256:abc123',
+    state: 'running',
   };
 
   const { getByText } = render(NameColumn, { object: containerRow });
@@ -98,6 +99,7 @@ test('should remove leading slash from container name', () => {
     id: 'container123456789',
     engineId: 'podman',
     imageID: 'sha256:abc123',
+    state: 'running',
   };
 
   const { getByText } = render(NameColumn, { object: containerRow });
@@ -112,6 +114,7 @@ test('should truncate container ID to 8 characters', () => {
     id: 'abcdefghijklmnop',
     engineId: 'podman',
     imageID: 'sha256:abc123',
+    state: 'running',
   };
 
   const { getByText } = render(NameColumn, { object: containerRow });

--- a/packages/frontend/src/routes/alternatives/(components)/columns/StatusColumn.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/StatusColumn.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
 import { StatusIcon } from '@podman-desktop/ui-svelte';
-import { ContainerIcon } from '@podman-desktop/ui-svelte/icons';
 
 import ImageIcon from '$lib/icons/ImageIcon.svelte';
+import type { LocalContainer, LocalImage } from '@podman-desktop/extension-hummingbird-core-api';
+import ContainerStatus from '/@/lib/columns/ContainerStatus.svelte';
 
 interface Props {
-  object: 'container' | 'image';
+  object: LocalContainer | LocalImage;
 }
 
 let { object }: Props = $props();
 </script>
 
-{#if object === 'container'}
-  <StatusIcon icon={ContainerIcon} />
+{#if 'state' in object}
+  <ContainerStatus object={object} />
 {:else}
   <StatusIcon icon={ImageIcon} />
 {/if}

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/table/ClonableContainerTable.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/table/ClonableContainerTable.svelte
@@ -3,7 +3,7 @@ import type { LocalContainer } from '@podman-desktop/extension-hummingbird-core-
 import { Table, TableColumn, TableRow } from '@podman-desktop/ui-svelte';
 import LocalContainerNameColumn from '$lib/columns/LocalContainerNameColumn.svelte';
 import HardenAction from '/@/routes/images/[engineId]/[imageId]/report/(components)/table/columns/HardenAction.svelte';
-import ContainerStatus from '/@/routes/images/[engineId]/[imageId]/report/(components)/table/columns/ContainerStatus.svelte';
+import ContainerStatus from '/@/lib/columns/ContainerStatus.svelte';
 
 interface Props {
   containers: Array<LocalContainer>;

--- a/packages/shared/src/models/local-container.ts
+++ b/packages/shared/src/models/local-container.ts
@@ -21,4 +21,5 @@ export interface LocalContainer {
   engineId: string;
   name: string;
   imageID: string;
+  state: 'running' | 'exited' | 'created' | string;
 }


### PR DESCRIPTION
## Description

Propagate the container status, so that we display the status with the appropriate icon / status.

:warning: this is not reactive, because we pull once the data, we don't have sync mechanism.

## Screenshots

<img width="966" height="126" alt="Screenshot From 2026-07-16 17-34-47" src="https://github.com/user-attachments/assets/6a99ae07-1d8f-494a-815b-1e71db22cc4c" />

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/269

## Testing

- [x] Unit tests have been added