### PR TITLE
chore(timeout): avoid timeout on image and alternative IPC

### DIFF
--- a/packages/shared/src/messages/constants.ts
+++ b/packages/shared/src/messages/constants.ts
@@ -22,6 +22,8 @@ import { ContainerApi } from '../apis/container-api';
 
 export const noTimeoutChannels: string[] = [
   getChannel(ImageApi, 'pull'),
+  getChannel(ImageApi, 'all'),
   getChannel(AlternativesApi, 'getAlternativeReport'),
+  getChannel(AlternativesApi, 'getAlternatives'),
   getChannel(ContainerApi, 'clone'),
 ];


### PR DESCRIPTION
## Description

Two IPC are failing on my machine when I am in power saving mode, those IPC are a bit heavy, so they might timeout, excluding them to avoid any issue.

## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/544