### PR TITLE
feat(frontend): disable auto-scan

### DIFF
--- a/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/AlternativeTable.svelte
@@ -7,7 +7,6 @@ import type {
   LocalImageAlternativeReport,
 } from '@podman-desktop/extension-hummingbird-core-api';
 import CVEReductionCell from './columns/CVEReductionColumn.svelte';
-import { alternativesAPI } from '/@/api/client';
 import FilesizeReductionColumn from './columns/FilesizeReductionColumn.svelte';
 import StatusColumn from './columns/StatusColumn.svelte';
 import type { Row } from '/@/routes/alternatives/(components)/row';
@@ -16,16 +15,16 @@ import ActionColumn from '/@/routes/alternatives/(components)/columns/ActionColu
 
 interface Props {
   alternatives: LocalImageAlternative[];
-  isGrypeInstalled: boolean;
+  reports: Map<string, Promise<LocalImageAlternativeReport>>;
 }
 
-let { alternatives, isGrypeInstalled }: Props = $props();
+let { alternatives, reports }: Props = $props();
 
 let data: Row[] = $derived(
   alternatives.map((alt, index) => ({
     ...alt,
     name: alt.localImage.name,
-    report: isGrypeInstalled ? alternativesAPI.getAlternativeReport(alt) : undefined,
+    report: reports.get(alt.localImage.id),
   })),
 );
 
@@ -42,7 +41,7 @@ let columns = $derived([
     renderer: NameColumn,
     overflow: false,
   }),
-  ...(isGrypeInstalled
+  ...(reports.size > 0
     ? [
         new TableColumn<Row, Promise<LocalImageAlternativeReport> | undefined>('CVEs', {
           width: '1fr',
@@ -86,4 +85,6 @@ function key(row: Row): string {
 }
 </script>
 
-<Table key={key} kind="alternatives" data={data} columns={columns} row={row} />
+{#key reports.size}
+  <Table key={key} kind="alternatives" data={data} columns={columns} row={row} />
+{/key}

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.spec.ts
@@ -102,7 +102,7 @@ test('should navigate to image report when info button is clicked', async () => 
   );
 });
 
-test('info button should have appropriate tooltip', async () => {
+test('info button should always show Open Image Report Details title', async () => {
   const alternativeRow = {
     name: 'nginx:latest',
     localImage: {
@@ -121,11 +121,9 @@ test('info button should have appropriate tooltip', async () => {
     report: undefined,
   } as unknown as AlternativeRow;
 
-  const { getByRole } = render(ActionColumn, { object: alternativeRow });
+  const { getByTitle } = render(ActionColumn, { object: alternativeRow });
 
-  const button = getByRole('button', {
-    name: 'You need to install Grype extension to access full report.',
-  });
+  const button = getByTitle('Open Image Report Details');
   expect(button).toBeInTheDocument();
 });
 

--- a/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
+++ b/packages/frontend/src/routes/alternatives/(components)/columns/ActionColumn.svelte
@@ -39,11 +39,8 @@ function onCloneContainer(engineId: string, containerId: string): Promise<void> 
 {#if 'report' in object}
   <ListItemButtonIcon
     icon={faInfoCircle}
-    enabled={object.report !== undefined}
     onClick={onOpenImageReport.bind(undefined, object.localImage.engineId, object.localImage.id)}
-    title={object.report
-      ? 'Open Image Report Details'
-      : 'You need to install Grype extension to access full report.'} />
+    title="Open Image Report Details" />
 {:else}
   <ListItemButtonIcon
     icon={faClone}

--- a/packages/frontend/src/routes/alternatives/+page.svelte
+++ b/packages/frontend/src/routes/alternatives/+page.svelte
@@ -1,16 +1,22 @@
 <script lang="ts">
-import { NavPage, EmptyScreen } from '@podman-desktop/ui-svelte';
+import { NavPage, EmptyScreen, Button } from '@podman-desktop/ui-svelte';
 import { faWarning } from '@fortawesome/free-solid-svg-icons/faWarning';
 import type { PageProps } from './$types';
 import AlternativeTable from '/@/routes/alternatives/(components)/AlternativeTable.svelte';
 import TableSkeleton from '$lib/skeleton/TableSkeleton.svelte';
 import { onMount } from 'svelte';
-import { rpcBrowser } from '/@/api/client';
+import { rpcBrowser, alternativesAPI } from '/@/api/client';
 import { invalidate } from '$app/navigation';
 import { Messages } from '@podman-desktop/extension-hummingbird-core-api';
 import GrypeBanner from '/@/routes/alternatives/(components)/banner/GrypeBanner.svelte';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
+import type { LocalImageAlternativeReport } from '@podman-desktop/extension-hummingbird-core-api/src';
+import { SvelteMap } from 'svelte/reactivity';
 
 let { data }: PageProps = $props();
+
+let reports: Map<string, Promise<LocalImageAlternativeReport>> = new SvelteMap();
+let reporting: boolean = $state(false);
 
 onMount(() => {
   const subscriber = rpcBrowser.subscribe(Messages.UPDATE_ALTERNATIVES, () => {
@@ -28,29 +34,44 @@ let columns = $derived([
     name: '',
     width: '2fr',
   },
-  ...(data.isGrypeInstalled
-    ? [
-        {
-          name: 'CVEs',
-          width: '1fr',
-        },
-        {
-          name: 'Size Reduction',
-          width: '1fr',
-        },
-      ]
-    : []),
   {
     name: 'Actions',
     width: '50px',
   },
 ]);
+
+async function analyze(): Promise<void> {
+  reporting = true;
+  reports.clear();
+
+  const promises: Array<Promise<LocalImageAlternativeReport>> = [];
+
+  const alternatives = await data.alternatives;
+
+  alternatives.forEach(alternative => {
+    const promise = alternativesAPI.getAlternativeReport(alternative);
+    promises.push(promise);
+
+    reports.set(alternative.localImage.id, promise);
+  });
+
+  await Promise.allSettled(promises);
+  reporting = false;
+}
 </script>
 
 <NavPage title="Hardened Image Alternatives" searchEnabled={false}>
+  {#snippet additionalActions()}
+    <Button
+      disabled={!data.isGrypeInstalled || reporting || reports.size > 0}
+      inProgress={reporting}
+      onclick={analyze}
+      icon={faMagnifyingGlass}
+      title="Analyze images">Analyze</Button>
+  {/snippet}
   {#snippet content()}
     {#await data.alternatives}
-      <TableSkeleton count={20} columns={columns} />
+      <TableSkeleton count={10} columns={columns} />
     {:then alternatives}
       {#if alternatives.length === 0}
         <EmptyScreen
@@ -66,7 +87,7 @@ let columns = $derived([
           {/if}
 
           <div class="w-full flex">
-            <AlternativeTable alternatives={alternatives} isGrypeInstalled={data.isGrypeInstalled} />
+            <AlternativeTable alternatives={alternatives} reports={reports} />
           </div>
         </div>
       {/if}

--- a/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/alternatives/page.svelte.spec.ts
@@ -18,11 +18,14 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { cleanup, render, within } from '@testing-library/svelte';
+import { cleanup, render, within, screen } from '@testing-library/svelte';
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { LocalImageAlternative } from '@podman-desktop/extension-hummingbird-core-api';
 import Page from './+page.svelte';
+import { rpcBrowser } from '/@/api/client';
+
+vi.mock(import('/@/api/client'));
 
 const ALTERNATIVES: Array<LocalImageAlternative> = [
   {
@@ -52,6 +55,7 @@ const ALTERNATIVES: Array<LocalImageAlternative> = [
 
 beforeEach(() => {
   vi.resetAllMocks();
+  vi.mocked(rpcBrowser.subscribe).mockReturnValue({ unsubscribe: vi.fn() });
 });
 
 describe('error', () => {
@@ -88,40 +92,37 @@ describe('loading', () => {
     expect(skeletons).toBeInTheDocument();
   });
 
-  test.each([true, false])(
-    'skeleton table columns should match alternatives table columns (isGrypeInstalled: %s)',
-    async isGrypeInstalled => {
-      const { getByRole: getSkeletonRole } = render(Page, {
-        data: {
-          alternatives: new Promise<Array<LocalImageAlternative>>(vi.fn()),
-          isGrypeInstalled,
-        },
-        params: {},
-      });
+  test('skeleton table columns should match alternatives table columns', async () => {
+    const { getByRole: getSkeletonRole } = render(Page, {
+      data: {
+        alternatives: new Promise<Array<LocalImageAlternative>>(vi.fn()),
+        isGrypeInstalled: false,
+      },
+      params: {},
+    });
 
-      const skeletonTable = getSkeletonRole('table', { name: 'loading' });
-      const skeletonHeaders = within(skeletonTable)
-        .getAllByRole('columnheader')
-        .map(el => el.textContent?.trim() ?? '');
+    const skeletonTable = getSkeletonRole('table', { name: 'loading' });
+    const skeletonHeaders = within(skeletonTable)
+      .getAllByRole('columnheader')
+      .map(el => el.textContent?.trim() ?? '');
 
-      cleanup();
+    cleanup();
 
-      const { getByRole } = render(Page, {
-        data: {
-          alternatives: Promise.resolve(ALTERNATIVES),
-          isGrypeInstalled,
-        },
-        params: {},
-      });
+    const { getByRole } = render(Page, {
+      data: {
+        alternatives: Promise.resolve(ALTERNATIVES),
+        isGrypeInstalled: false,
+      },
+      params: {},
+    });
 
-      const alternativesTable = await vi.waitFor(() => getByRole('table', { name: 'alternatives' }));
-      const actualHeaders = within(alternativesTable)
-        .getAllByRole('columnheader')
-        .map(el => el.textContent?.trim() ?? '');
+    const alternativesTable = await vi.waitFor(() => getByRole('table', { name: 'alternatives' }));
+    const actualHeaders = within(alternativesTable)
+      .getAllByRole('columnheader')
+      .map(el => el.textContent?.trim() ?? '');
 
-      expect(skeletonHeaders).toEqual(actualHeaders);
-    },
-  );
+    expect(skeletonHeaders).toEqual(actualHeaders);
+  });
 });
 
 describe('data', () => {
@@ -151,5 +152,33 @@ describe('data', () => {
     await vi.waitFor(() => {
       expect(getByLabelText('No alternatives found')).toBeDefined();
     });
+  });
+});
+
+describe('analyze button', () => {
+  test('should be disabled when grype is not installed', async () => {
+    render(Page, {
+      data: {
+        alternatives: Promise.resolve(ALTERNATIVES),
+        isGrypeInstalled: false,
+      },
+      params: {},
+    });
+
+    const button = await vi.waitFor(() => screen.getByTitle('Analyze images'));
+    expect(button).toBeDisabled();
+  });
+
+  test('should be enabled when grype is installed', async () => {
+    render(Page, {
+      data: {
+        alternatives: Promise.resolve(ALTERNATIVES),
+        isGrypeInstalled: true,
+      },
+      params: {},
+    });
+
+    const button = await vi.waitFor(() => screen.getByTitle('Analyze images'));
+    expect(button).toBeEnabled();
   });
 });

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/grype/ExtensionBanner.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/(components)/grype/ExtensionBanner.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+import { Icon } from '@podman-desktop/ui-svelte/icons';
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons/faMagnifyingGlass';
+import { routingAPI } from '/@/api/client';
+
+let featuredExtension = {
+  displayName: 'Grype',
+  description: 'Grype and Syft integration in Podman Desktop',
+  icon: 'https://registry.podman-desktop.io/api/extensions/podman-desktop/grype/0.1.0/icon.png',
+};
+
+function navigateToCatalog(): Promise<void> {
+  return routingAPI.navigateToCatalog('grype');
+}
+</script>
+
+<div
+  title={featuredExtension.description}
+  class="bg-(--pd-invert-content-card-bg) border-(--pd-invert-content-card-bg) rounded-md flex flex-row justify-center p-4 border hover:border-(--pd-content-card-border-selected)"
+  aria-label={featuredExtension.displayName}>
+  <div class="flex flex-col flex-1">
+    <div class="flex flex-row place-items-center flex-1">
+      <div>
+        <img class="w-12 h-12 object-contain" alt="{featuredExtension.displayName} logo" src={featuredExtension.icon} />
+      </div>
+      <div class="flex flex-1 mx-2 cursor-default font-bold justify-start text-(--pd-details-body-text)">
+        {featuredExtension.displayName}
+      </div>
+      <div class="h-full w-18 flex flex-col items-end place-content-center">
+        <button
+          aria-label="Open catalog"
+          onclick={navigateToCatalog}
+          title="Open catalog"
+          class="border-2 relative rounded-sm border-(--pd-button-secondary-border) text-(--pd-button-secondary-text) hover:bg-(--pd-button-secondary-hover-bg) w-10 p-2 text-center cursor-pointer flex flex-row justify-center">
+          <Icon class="ml-1.5 mr-2" size="1.1x" icon={faMagnifyingGlass} />
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.svelte
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
 import type { PageProps } from './$types';
 import OptimisationReport from '/@/routes/images/[engineId]/[imageId]/report/(components)/report/OptimisationReport.svelte';
-import { DetailsPage } from '@podman-desktop/ui-svelte';
+import { DetailsPage, EmptyScreen } from '@podman-desktop/ui-svelte';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
+import { faWarning } from '@fortawesome/free-solid-svg-icons/faWarning';
+import ExtensionBanner from './(components)/grype/ExtensionBanner.svelte';
+import { faLightbulb } from '@fortawesome/free-solid-svg-icons/faLightbulb';
 
 let { data }: PageProps = $props();
 
@@ -19,12 +22,28 @@ function close(): Promise<void> {
   onbreadcrumbClick={close}
   onclose={close}>
   {#snippet contentSnippet()}
-    {#await data.report}
-      <span>Loading...</span>
-    {:then report}
-      <div class="pt-5 w-full">
-        <OptimisationReport object={report} />
-      </div>
-    {/await}
+    {#if data.isGrypeInstalled}
+      {#await data.report}
+        <span>Loading...</span>
+      {:then report}
+        <div class="pt-5 w-full">
+          <OptimisationReport object={report} />
+        </div>
+      {:catch error}
+        <EmptyScreen
+          icon={faWarning}
+          title="Error loading optimisation report"
+          aria-label="Error loading optimisation report"
+          message={error}>
+        </EmptyScreen>
+      {/await}
+    {:else}
+      <EmptyScreen
+        icon={faLightbulb}
+        title="You need to install Grype to use this feature"
+        aria-label="You need to install Grype to use this feature">
+        <ExtensionBanner />
+      </EmptyScreen>
+    {/if}
   {/snippet}
 </DetailsPage>

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/+page.ts
@@ -23,6 +23,7 @@ import { IMAGE_QUERY_KEY } from '/@/routes/images/[engineId]/[imageId]/report/co
 interface Data {
   engineId: string;
   image: string;
+  isGrypeInstalled: boolean;
   report: Promise<OptimisationReport>;
 }
 
@@ -30,8 +31,11 @@ export const load: PageLoad = async ({ params, url }): Promise<Data> => {
   const engineId = decodeURIComponent(params.engineId);
   const imageId = decodeURIComponent(params.imageId);
 
+  const isGrypeInstalled = await alternativesAPI.isGrypeInstalled();
+
   return {
     engineId,
+    isGrypeInstalled,
     image: url.searchParams.get(IMAGE_QUERY_KEY) ?? '<unknown>',
     report: alternativesAPI.getOptimisationReport(engineId, imageId),
   };

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/page.svelte.spec.ts
@@ -18,7 +18,7 @@
 
 import '@testing-library/jest-dom/vitest';
 
-import { render, screen } from '@testing-library/svelte';
+import { render } from '@testing-library/svelte';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { OptimisationReport } from '@podman-desktop/extension-hummingbird-core-api';
 import Page from './+page.svelte';
@@ -32,7 +32,7 @@ beforeEach(() => {
 
 describe('when grype is not installed', () => {
   test('should display install prompt', () => {
-    render(Page, {
+    const { getByLabelText } = render(Page, {
       data: {
         engineId: 'podman',
         image: 'nginx:latest',
@@ -45,12 +45,12 @@ describe('when grype is not installed', () => {
       },
     });
 
-    const emptyScreen = screen.getByLabelText('You need to install Grype to use this feature');
+    const emptyScreen = getByLabelText('You need to install Grype to use this feature');
     expect(emptyScreen).toBeInTheDocument();
   });
 
   test('should render the ExtensionBanner', () => {
-    render(Page, {
+    const { getByLabelText } = render(Page, {
       data: {
         engineId: 'podman',
         image: 'nginx:latest',
@@ -63,14 +63,14 @@ describe('when grype is not installed', () => {
       },
     });
 
-    const banner = screen.getByLabelText('Grype');
+    const banner = getByLabelText('Grype');
     expect(banner).toBeInTheDocument();
   });
 });
 
 describe('when grype is installed', () => {
   test('should show loading text while report is pending', () => {
-    render(Page, {
+    const { getByText } = render(Page, {
       data: {
         engineId: 'podman',
         image: 'nginx:latest',
@@ -83,11 +83,11 @@ describe('when grype is installed', () => {
       },
     });
 
-    expect(screen.getByText('Loading...')).toBeInTheDocument();
+    expect(getByText('Loading...')).toBeInTheDocument();
   });
 
   test('should show error screen when report promise rejects', async () => {
-    render(Page, {
+    const { getByLabelText } = render(Page, {
       data: {
         engineId: 'podman',
         image: 'nginx:latest',
@@ -100,7 +100,7 @@ describe('when grype is installed', () => {
       },
     });
 
-    const errorScreen = await vi.waitFor(() => screen.getByLabelText('Error loading optimisation report'));
+    const errorScreen = await vi.waitFor(() => getByLabelText('Error loading optimisation report'));
     expect(errorScreen).toBeInTheDocument();
   });
 });

--- a/packages/frontend/src/routes/images/[engineId]/[imageId]/report/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/images/[engineId]/[imageId]/report/page.svelte.spec.ts
@@ -1,0 +1,106 @@
+/**********************************************************************
+ * Copyright (C) 2026 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import '@testing-library/jest-dom/vitest';
+
+import { render, screen } from '@testing-library/svelte';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { OptimisationReport } from '@podman-desktop/extension-hummingbird-core-api';
+import Page from './+page.svelte';
+
+vi.mock(import('$app/navigation'));
+vi.mock(import('/@/api/client'));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('when grype is not installed', () => {
+  test('should display install prompt', () => {
+    render(Page, {
+      data: {
+        engineId: 'podman',
+        image: 'nginx:latest',
+        isGrypeInstalled: false,
+        report: new Promise<OptimisationReport>(vi.fn()),
+      },
+      params: {
+        engineId: 'podman',
+        imageId: 'sha256:abc123',
+      },
+    });
+
+    const emptyScreen = screen.getByLabelText('You need to install Grype to use this feature');
+    expect(emptyScreen).toBeInTheDocument();
+  });
+
+  test('should render the ExtensionBanner', () => {
+    render(Page, {
+      data: {
+        engineId: 'podman',
+        image: 'nginx:latest',
+        isGrypeInstalled: false,
+        report: new Promise<OptimisationReport>(vi.fn()),
+      },
+      params: {
+        engineId: 'podman',
+        imageId: 'sha256:abc123',
+      },
+    });
+
+    const banner = screen.getByLabelText('Grype');
+    expect(banner).toBeInTheDocument();
+  });
+});
+
+describe('when grype is installed', () => {
+  test('should show loading text while report is pending', () => {
+    render(Page, {
+      data: {
+        engineId: 'podman',
+        image: 'nginx:latest',
+        isGrypeInstalled: true,
+        report: new Promise<OptimisationReport>(vi.fn()),
+      },
+      params: {
+        engineId: 'podman',
+        imageId: 'sha256:abc123',
+      },
+    });
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  test('should show error screen when report promise rejects', async () => {
+    render(Page, {
+      data: {
+        engineId: 'podman',
+        image: 'nginx:latest',
+        isGrypeInstalled: true,
+        report: Promise.reject(new Error('Something went wrong')),
+      },
+      params: {
+        engineId: 'podman',
+        imageId: 'sha256:abc123',
+      },
+    });
+
+    const errorScreen = await vi.waitFor(() => screen.getByLabelText('Error loading optimisation report'));
+    expect(errorScreen).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Instead of auto scanning all images in the local registry that have Hummingbird alternatives, adding a `Analyze` button, that will trigger the process.

## Screenshots

https://github.com/user-attachments/assets/9fe5b052-2a5c-4a7f-b031-177d9c229d1e

This come with another challenge, the report details page need to have an "empty state" as we don't pre-compute the report, and we can't rely on this information to disable or not the `(i)` button.

<img width="1516" height="1065" alt="image" src="https://github.com/user-attachments/assets/3d6ff969-36f3-4bca-bbac-7aff34ccb384" />


## Related issues

Fixes https://github.com/redhat-developer/podman-desktop-hummingbird-ext/issues/475

## Testing

- [x] Unit tests have been provided