### PR TITLE
fix: resolve CVE-2026-13149 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       "ajv@^6": "^6.14.0",
       "ajv@>=7": ">=8.18.0",
       "brace-expansion@^1": "^1.1.13",
-      "brace-expansion@^5": ">=5.0.6",
+      "brace-expansion@^5": ">=5.0.7",
       "cookie": "0.7.0",
       "postcss": "^8.5.12",
       "esbuild": ">=0.28.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   ajv@^6: ^6.14.0
   ajv@>=7: '>=8.18.0'
   brace-expansion@^1: ^1.1.13
-  brace-expansion@^5: '>=5.0.6'
+  brace-expansion@^5: '>=5.0.7'
   cookie: 0.7.0
   postcss: ^8.5.12
   esbuild: '>=0.28.1'
@@ -1541,8 +1541,8 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5038,7 +5038,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6202,7 +6202,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-13149 in `brace-expansion`.

**Advisory**: brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups
**Vulnerable versions**: >=3.0.0 <5.0.7
**Patched versions**: >=5.0.7
**Advisory URL**: https://github.com/advisories/GHSA-3jxr-9vmj-r5cp

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-13149: _brace-expansion: DoS via exponential-time expansion of consecutive non-expanding {} groups_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-13149 is no longer reported