### PR TITLE
fix: resolve CVE-2026-13311 in shell-quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
       "js-yaml": ">=4.2.0",
       "dompurify": ">=3.4.11",
       "undici@>=7": ">=7.28.0 <8",
-      "undici@^6": ">=6.27.0 <7"
+      "undici@^6": ">=6.27.0 <7",
+      "shell-quote": ">=1.9.0"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   dompurify: '>=3.4.11'
   undici@>=7: '>=7.28.0 <8'
   undici@^6: '>=6.27.0 <7'
+  shell-quote: '>=1.9.0'
 
 importers:
 
@@ -3068,8 +3069,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   should-equal@2.0.0:
@@ -5155,7 +5156,7 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       supports-color: 10.2.2
       tree-kill: 1.2.2
       yargs: 18.0.0
@@ -6646,7 +6647,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   should-equal@2.0.0:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-13311 in `shell-quote`.

**Advisory**: shell-quote: Quadratic-complexity Denial of Service in `parse()` (CWE-407)
**Vulnerable versions**: <=1.8.4
**Patched versions**: >=1.9.0
**Advisory URL**: https://github.com/advisories/GHSA-395f-4hp3-45gv

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-13311: _shell-quote: Quadratic-complexity Denial of Service in `parse()` (CWE-407)_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-13311 is no longer reported