### PR TITLE
chore(ci): add eslint and typescript-eslint dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
       time: "02:00"
     open-pull-requests-limit: 10
     groups:
+      eslint:
+        applies-to: version-updates
+        patterns:
+          - "eslint"
+          - "@eslint/*"
       fortawesome:
         applies-to: version-updates
         patterns:
@@ -27,6 +32,11 @@ updates:
         patterns:
           - "@tailwindcss/*"
           - "tailwindcss"
+      typescript-eslint:
+        applies-to: version-updates
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
       vitest:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## What does this PR do?

Adds `eslint` and `typescript-eslint` groups to `dependabot.yml`, aligning with the [upstream podman-desktop config](https://github.com/podman-desktop/podman-desktop/blob/main/.github/dependabot.yml).

### Why?

Dependabot hasn't opened a PR for eslint v10 (#520) because `eslint` and `@eslint/*` aren't grouped. Without a group, dependabot treats the `^9 → ^10` major bump as two separate updates and skips them.

Upstream uses these groups and dependabot successfully bumps eslint v10 there (e.g. [podman-desktop#18450](https://github.com/podman-desktop/podman-desktop/pull/18450)).

I verified locally that bumping `eslint` to `^10.8.0` and `@eslint/js` to `^10.0.1` works out of the box: install, lint, build, and all 152 tests pass with no code changes needed (beyond the `eslint-plugin-etc` removal in #580).

### Groups added

| Group | Packages | Matches upstream? |
|---|---|---|
| `eslint` | `eslint`, `@eslint/*` | Yes |
| `typescript-eslint` | `@typescript-eslint/*`, `typescript-eslint` | Yes |

## How to test this PR?

1. Merge this + #580
2. Wait for the next dependabot run (daily at 02:00 UTC)
3. Dependabot should open a grouped PR bumping `eslint` and `@eslint/js` to v10


Made with [Cursor](https://cursor.com)