### PR TITLE
chore(tsconfig): remove deprecated options for TypeScript 6

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "sourceMap": true,
     "outDir": "dist",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,11 +2,9 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
-    "preserveValueImports": false,
     "skipLibCheck": true,
-    "baseUrl": ".",
     "allowJs": true,
     "checkJs": true
   },


### PR DESCRIPTION
## What does this PR do?

Removes deprecated tsconfig options that cause hard errors with TypeScript 6:

| File | Option removed | Replacement |
|---|---|---|
| `packages/shared/tsconfig.json` | `moduleResolution: "node"` | `"bundler"` |
| `packages/shared/tsconfig.json` | `baseUrl: "."` | Removed (not used by any imports) |
| `packages/shared/tsconfig.json` | `preserveValueImports: false` | Removed (deprecated since TS 5.5) |
| `packages/backend/tsconfig.json` | `moduleResolution: "Node"` | `"bundler"` |

This matches the fix applied upstream in podman-desktop: https://github.com/podman-desktop/podman-desktop/pull/17992

### Why?

Unblocks the dependabot TypeScript 5→6 upgrade PR (#583, #522). Without this, `pnpm typecheck` fails with TS5107/TS5101 deprecation errors.

## How to test this PR?

1. Merge this PR
2. Re-run CI on #583 — typecheck should now pass
3. Or verify locally: set `typescript` to `6.0.3` in `package.json`, run `pnpm install && pnpm typecheck`


Made with [Cursor](https://cursor.com)