### PR TITLE
chore(lint): fix new sonarjs 4.2.0 lint errors

### DIFF
--- a/packages/backend/src/services/webview-service.ts
+++ b/packages/backend/src/services/webview-service.ts
@@ -52,8 +52,7 @@ export class WebviewService implements Disposable, AsyncInit {
 
     // replace links with webView Uri links
     // in the content <script type="module" crossorigin src="./index-RKnfBG18.js"></script> replace src with webview.asWebviewUri
-    // eslint-disable-next-line sonarjs/slow-regex
-    const scriptLink = indexHtml.match(/<script.*?src="(.*?)".*?>/g);
+    const scriptLink = indexHtml.match(/<script[^>]*\bsrc="([^"]*)"[^>]*>/g);
     if (scriptLink) {
       scriptLink.forEach(link => {
         const src = RegExp(/src="(.*?)"/).exec(link);
@@ -66,8 +65,7 @@ export class WebviewService implements Disposable, AsyncInit {
     }
 
     // and now replace for css file as well
-    // eslint-disable-next-line sonarjs/slow-regex
-    const cssLink = indexHtml.match(/<link.*?href="(.*?)".*?>/g);
+    const cssLink = indexHtml.match(/<link[^>]*\bhref="([^"]*)"[^>]*>/g);
     if (cssLink) {
       cssLink.forEach(link => {
         const href = RegExp(/href="(.*?)"/).exec(link);

--- a/packages/frontend/src/lib/icons/RepositoryIcon.spec.ts
+++ b/packages/frontend/src/lib/icons/RepositoryIcon.spec.ts
@@ -41,7 +41,7 @@ describe('RepositoryIcon', () => {
     expect(svg).toBeDefined();
 
     const paths = container.querySelectorAll('path');
-    expect(paths.length).toBe(2);
+    expect(paths).toHaveLength(2);
     expect(paths[0]).toHaveAttribute('fill', 'var(--pd-label-primary-bg)');
     expect(paths[1]).toHaveAttribute('fill', 'var(--pd-link)');
   });
@@ -54,7 +54,7 @@ describe('RepositoryIcon', () => {
     expect(svg).toBeDefined();
 
     const paths = container.querySelectorAll('path');
-    expect(paths.length).toBe(2);
+    expect(paths).toHaveLength(2);
     expect(paths[0]).toHaveAttribute('fill', 'var(--pd-label-primary-bg)');
     expect(paths[1]).toHaveAttribute('fill', 'var(--pd-link)');
   });

--- a/packages/frontend/src/lib/selects/ContainerProviderConnectionSelect.spec.ts
+++ b/packages/frontend/src/lib/selects/ContainerProviderConnectionSelect.spec.ts
@@ -55,7 +55,7 @@ test('Should list all container provider connections', async () => {
   // get all options available
   const items: string[] = await select.getOptions();
   // ensure we have two options
-  expect(items.length).toBe(2);
+  expect(items).toHaveLength(2);
   expect(items[0]).toContain(wslConnection.name);
   expect(items[1]).toContain(qemuConnection.name);
 });

--- a/packages/frontend/src/lib/selects/Select.spec.ts
+++ b/packages/frontend/src/lib/selects/Select.spec.ts
@@ -48,7 +48,7 @@ test('empty slot should use basic list', async () => {
   // get all options available
   const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
   // ensure we have two options
-  expect(items.length).toBe(2);
+  expect(items).toHaveLength(2);
   expect(items[0]).toHaveTextContent('Dummy Item 1');
   expect(items[1]).toHaveTextContent('Dummy Item 2');
 });
@@ -79,10 +79,10 @@ test('defined value should have corresponding active class to item', async () =>
   // get all options available
   const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
   // ensure we have two options
-  expect(items.length).toBe(2);
-  expect(items[0].children.length).toBe(1);
+  expect(items).toHaveLength(2);
+  expect(items[0].children).toHaveLength(1);
   expect(items[0].children[0].classList.value).not.toContain('active');
-  expect(items[1].children.length).toBe(1);
+  expect(items[1].children).toHaveLength(1);
   expect(items[1].children[0].classList.value).toContain('active');
 });
 
@@ -110,7 +110,7 @@ test('selecting value should call onchange callback', async () => {
   // get all options available
   const items: NodeListOf<HTMLElement> = container.querySelectorAll('div[class~="list-item"]');
   // ensure we have two options
-  expect(items.length).toBe(2);
+  expect(items).toHaveLength(2);
 
   await fireEvent.click(items[1]);
 

--- a/packages/frontend/src/routes/page.svelte.spec.ts
+++ b/packages/frontend/src/routes/page.svelte.spec.ts
@@ -105,7 +105,7 @@ describe('loading', () => {
     });
 
     const skeletons = getAllByLabelText('Loading repository card');
-    expect(skeletons.length).toBe(10);
+    expect(skeletons).toHaveLength(10);
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes lint errors that will be introduced when eslint-plugin-sonarjs is bumped from 4.0.3 to 4.2.0 (#539).

### Fixes

- **`sonarjs/slow-regex`** (renamed from `super-linear-regex` in 4.2.0): replaced backtracking-prone `.*?` patterns with `[^>]*` and `[^"]*` in HTML regex matching (`webview-service.ts`)
- **`sonarjs/prefer-specific-assertions`**: use `toHaveLength(n)` instead of `expect(x.length).toBe(n)` across test files for better error reporting

## How to test this PR?

Merge this, then rebase #539 — lint should now pass


Made with [Cursor](https://cursor.com)