### PR TITLE
fix: resolve CVE-2026-67213 in nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,9 @@
       "dompurify": ">=3.4.11",
       "undici@>=7": ">=7.28.0 <8",
       "undici@^6": ">=6.27.0 <7",
-      "shell-quote": ">=1.9.0"
+      "shell-quote": ">=1.9.0",
+      "nanoid@^3": "^3.3.18",
+      "nanoid@^5": "^5.1.16"
     }
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   undici@>=7: '>=7.28.0 <8'
   undici@^6: '>=6.27.0 <7'
   shell-quote: '>=1.9.0'
+  nanoid@^3: ^3.3.18
+  nanoid@^5: ^5.1.16
 
 importers:
 
@@ -2664,11 +2666,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
 
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
@@ -6179,8 +6176,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
-
   nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
@@ -6379,7 +6374,7 @@ snapshots:
 
   postcss@8.5.20:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-67213 in `nanoid`.

**Advisory**: nanoid: custom generators can loop indefinitely when size is zero
**Vulnerable versions**: <3.3.18
**Patched versions**: >=3.3.18
**Advisory URL**: https://github.com/advisories/GHSA-2v37-7h3g-55p8

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-67213: _nanoid: custom generators can loop indefinitely when size is zero_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-67213 is no longer reported