### PR TITLE
fix: resolve GHSA-7p8r-x3mc-p8w7 in fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,8 @@ overrides:
   shell-quote: '>=1.9.0'
   nanoid@^3: ^3.3.18
   nanoid@^5: ^5.1.16
+  fast-uri@^3: ^3.1.5
+  fast-uri@^4: ^4.1.2
 
 importers:
 
@@ -2009,8 +2011,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -4826,7 +4828,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5596,7 +5598,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.19.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,8 @@ overrides:
   shell-quote: '>=1.9.0'
   nanoid@^3: ^3.3.18
   nanoid@^5: ^5.1.16
+  fast-uri@^3: ^3.1.5
+  fast-uri@^4: ^4.1.2
 nodeLinker: hoisted
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-7p8r-x3mc-p8w7 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via backslash authority introducer
**Vulnerable versions**: >=3.0.0 <3.1.5
**Patched versions**: >=3.1.5
**Advisory URL**: https://github.com/advisories/GHSA-7p8r-x3mc-p8w7

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-7p8r-x3mc-p8w7: _fast-uri vulnerable to host confusion via backslash authority introducer_

### How to test this PR?

Run `pnpm audit` and verify GHSA-7p8r-x3mc-p8w7 is no longer reported