### PR TITLE
fix: resolve GHSA-55q2-fjhq-7xh7 in dompurify

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ overrides:
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
   js-yaml: '>=4.2.0'
-  dompurify: '>=3.4.11'
+  dompurify: '>=3.4.13'
   undici@>=7: '>=7.28.0 <8'
   undici@^6: '>=6.27.0 <7'
   shell-quote: '>=1.9.0'
@@ -1730,8 +1730,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -5194,7 +5194,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -7359,7 +7359,7 @@ snapshots:
       class-variance-authority: 0.7.1
       clsx: 2.1.1
       dayjs: 1.11.21
-      dompurify: 3.4.12
+      dompurify: 3.4.13
       nanoid: 5.1.16
       tailwind-merge: 3.6.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ overrides:
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
   js-yaml: '>=4.2.0'
-  dompurify: '>=3.4.11'
+  dompurify: '>=3.4.13'
   undici@>=7: '>=7.28.0 <8'
   undici@^6: '>=6.27.0 <7'
   shell-quote: '>=1.9.0'


### PR DESCRIPTION
### What does this PR do?

Fix moderate severity vulnerability GHSA-55q2-fjhq-7xh7 in `dompurify`.

**Advisory**: DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS
**Vulnerable versions**: <=3.4.12
**Patched versions**: >=3.4.13
**Advisory URL**: https://github.com/advisories/GHSA-55q2-fjhq-7xh7

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-55q2-fjhq-7xh7: _DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS_

### How to test this PR?

Run `pnpm audit` and verify GHSA-55q2-fjhq-7xh7 is no longer reported