### PR TITLE
fix: resolve GHSA-pm4m-ph32-ghv5 in js-yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,8 @@ overrides:
   cookie: 0.7.0
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
-  js-yaml: '>=4.2.0'
+  js-yaml@^4: 4.3.1
+  js-yaml@^5: ^5.3.0
   dompurify: '>=3.4.13'
   undici@>=7: '>=7.28.0 <8'
   undici@^6: '>=6.27.0 <7'
@@ -2387,8 +2388,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -3789,7 +3790,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.0.1':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 5.2.1
+      js-yaml: 4.3.1
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -3952,7 +3953,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 5.2.1
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5951,7 +5952,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,8 @@ overrides:
   cookie: 0.7.0
   postcss: '>=8.5.18'
   esbuild: '>=0.28.1'
-  js-yaml: '>=4.2.0'
+  js-yaml@^4: 4.3.1
+  js-yaml@^5: ^5.3.0
   dompurify: '>=3.4.13'
   undici@>=7: '>=7.28.0 <8'
   undici@^6: '>=6.27.0 <7'


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-pm4m-ph32-ghv5 in `js-yaml`.

**Advisory**: js-yaml: Exponential parsing time in flow collections leads to denial of service
**Vulnerable versions**: >=5.0.0 <=5.2.1
**Patched versions**: >=5.2.2
**Advisory URL**: https://github.com/advisories/GHSA-pm4m-ph32-ghv5

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-pm4m-ph32-ghv5: _js-yaml: Exponential parsing time in flow collections leads to denial of service_

### How to test this PR?

Run `pnpm audit` and verify GHSA-pm4m-ph32-ghv5 is no longer reported